### PR TITLE
プラグイン骨格とComposer/NPMセットアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+docs/
+.DS_Store
+CLAUDE.md
+
+# PHP
+/vendor/
+composer.lock
+
+# Node
+/node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build
+/build/
+/dist/
+/assets/js/*.js
+/assets/js/*.asset.php
+/assets/js/*.map
+
+# wp-env
+.wp-env.override.json
+
+# Tests
+/.phpunit.result.cache
+/tests/coverage/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,292 @@
-# optrion
-[WordPress Plugin] Track, score, quarantine, and clean orphaned wp_options rows. Identify stale plugin/theme settings with read-tracking and staleness scoring — safely test-delete with quarantine mode before committing.
+<p align="center">
+  <img src="assets/optrion-icon.svg" width="72" height="72" alt="Optrion">
+</p>
+
+<h1 align="center">Optrion</h1>
+
+<p align="center">
+  <strong>Track, score, quarantine, and clean orphaned options in your WordPress database.</strong>
+</p>
+
+<p align="center">
+  <a href="#features">Features</a> •
+  <a href="#how-it-works">How It Works</a> •
+  <a href="#scoring">Scoring</a> •
+  <a href="#quarantine-mode">Quarantine</a> •
+  <a href="#wp-cli">WP-CLI</a> •
+  <a href="#rest-api">REST API</a> •
+  <a href="#installation">Installation</a> •
+  <a href="#faq">FAQ</a> •
+  <a href="#contributing">Contributing</a> •
+  <a href="#license">License</a>
+</p>
+
+---
+
+## The Problem
+
+Every plugin and theme writes settings to the `wp_options` table. When you deactivate or delete them, those rows stay behind — forever.
+
+Over time your options table accumulates hundreds of orphaned rows, many with `autoload = yes`, quietly inflating every single page load. There's no built-in way to tell which rows are still in use, which plugin created them, or whether it's safe to remove them.
+
+**Optrion fixes this.** It observes which options are actually read, identifies their owner, calculates a staleness score, and lets you safely quarantine or remove the dead weight — with full backup and one-click restore.
+
+## Features
+
+- **Read tracking** — hooks into `alloptions` and `option_{$name}` filters to record when each option was last read and by which plugin or theme.
+- **Owner detection** — traces `get_option()` call stacks back to the originating plugin/theme directory. Falls back to prefix-matching against installed plugins.
+- **Staleness scoring** — rates every option 0–100 based on owner activity, read recency, transient status, autoload waste, and data size.
+- **Quarantine mode** — renames options instead of deleting them. If something breaks, restore with one click. Auto-restores on expiry (safe by default).
+- **Bulk cleanup** — delete by score threshold, by owner, or expired transients only. Every delete auto-creates a JSON backup.
+- **Export / Import** — full JSON backup with option values, tracking metadata, and scores. Import with dry-run preview and optional overwrite.
+- **Dashboard** — React-based admin UI with score distribution charts, autoload size metrics, and owner breakdown.
+- **WP-CLI support** — every operation available from the command line.
+- **Core protection** — ~60 known WordPress core options are hardcoded as undeletable.
+
+## How It Works
+
+```
+  get_option()
+       │
+       ▼
+┌─────────────┐     shutdown      ┌──────────────────┐
+│   Tracker    │ ──── batch ────▶ │  tracking table   │
+│ (in-memory)  │     upsert       │  last_read_at     │
+└─────────────┘                   │  read_count       │
+                                  │  last_reader      │
+                                  └────────┬──────────┘
+                                           │
+                                  ┌────────▼──────────┐
+                                  │     Scorer         │
+                                  │  0–100 staleness   │
+                                  └────────┬──────────┘
+                                           │
+                              ┌────────────┼────────────┐
+                              ▼            ▼            ▼
+                         [ Quarantine ] [ Delete ] [ Export ]
+```
+
+Tracking is **sampling-based and batched**. Reads are buffered in memory during a request and flushed to the database once at `shutdown`. Tracking activates automatically for 10 minutes when an admin visits the dashboard — no always-on overhead.
+
+## Scoring
+
+Each option is scored across five axes:
+
+| Axis | Max Points | Condition |
+|------|-----------|-----------|
+| **Owner status** | 40 | Owning plugin/theme is deactivated (40) or owner unknown (20) |
+| **Read recency** | 25 | Last read 90+ days ago (5 pts per 30 days, capped at 25). No read recorded = 25 |
+| **Transient** | 10 | Option name starts with `_transient_` or `_site_transient_` |
+| **Autoload waste** | 15 | `autoload = yes` but zero reads during tracking period |
+| **Data size** | 10 | Over 100 KB = 10, over 10 KB = 5 |
+
+Total is capped at 100. The UI maps scores to four tiers:
+
+| Score | Label | Recommended Action |
+|-------|-------|--------------------|
+| 0–19 | Safe | Leave as is |
+| 20–49 | Review | Re-check periodically |
+| 50–79 | Likely stale | Quarantine first, then delete |
+| 80–100 | Almost certainly stale | Quarantine or export + delete |
+
+## Quarantine Mode
+
+Not sure if an option is safe to delete? **Quarantine it first.**
+
+Quarantine renames the option in `wp_options` (e.g. `wpseo_titles` → `_optrion_q__wpseo_titles`) and sets `autoload` to `no`. WordPress and the owning plugin will behave as if the option doesn't exist.
+
+```
+Quarantine ──▶ Run your site for a few days
+                    │
+        ┌───────────┴───────────┐
+  Something broke?         Everything fine?
+        │                       │
+    [Restore]              [Permanent Delete]
+    one click               with JSON backup
+```
+
+**Safe by default:** if the quarantine period expires without action, Optrion **auto-restores** the option and notifies the admin. You can change this to auto-delete or indefinite hold in settings.
+
+- Default quarantine period: **7 days** (configurable 1–30 days)
+- Maximum simultaneous quarantines: **50 options**
+- Core options cannot be quarantined
+
+## WP-CLI
+
+```bash
+# List options with scores
+wp optrion list --score-min=50 --format=table
+
+# Show summary statistics
+wp optrion stats
+
+# Export options scoring 50+ to JSON
+wp optrion export --score-min=50 --output=backup.json
+
+# Import with dry-run preview
+wp optrion import backup.json --dry-run
+
+# Import for real
+wp optrion import backup.json
+
+# Delete all options scoring 80+
+wp optrion clean --score-min=80 --yes
+
+# Clean up expired transients
+wp optrion clean-transients
+
+# Quarantine specific options for 14 days
+wp optrion quarantine wpseo_titles wpseo_social --days=14
+
+# List quarantined options
+wp optrion quarantine list
+
+# Restore from quarantine
+wp optrion quarantine restore wpseo_titles
+
+# Permanently delete from quarantine
+wp optrion quarantine delete wpseo_titles --yes
+
+# Run expiry check (same as daily cron)
+wp optrion quarantine check-expiry
+
+# Manual tracking snapshot
+wp optrion scan
+```
+
+## REST API
+
+Base: `/wp-json/optrion/v1`
+
+All endpoints require the `manage_options` capability.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/options` | List options with tracking data and scores. Supports `page`, `per_page`, `orderby`, `order`, `score_min`, `score_max`, `owner_type`, `search`. |
+| `GET` | `/options/{name}` | Single option detail |
+| `DELETE` | `/options` | Bulk delete (auto-backup) |
+| `GET` | `/stats` | Summary statistics |
+| `POST` | `/export` | Export selected options to JSON |
+| `POST` | `/import` | Import from JSON |
+| `POST` | `/import/preview` | Dry-run import preview |
+| `POST` | `/quarantine` | Quarantine selected options |
+| `GET` | `/quarantine` | List quarantined options |
+| `POST` | `/quarantine/restore` | Restore from quarantine |
+| `DELETE` | `/quarantine` | Permanently delete quarantined options |
+| `PATCH` | `/quarantine/{name}` | Extend period or update notes |
+| `POST` | `/scan` | Trigger manual tracking snapshot |
+
+## Installation
+
+### From source
+
+```bash
+git clone https://github.com/your-username/optrion.git
+cd optrion
+composer install
+npm install && npm run build
+```
+
+Copy the `optrion` directory to `wp-content/plugins/` and activate from the WordPress admin.
+
+### Requirements
+
+- WordPress 5.8+
+- PHP 7.4+
+- MySQL 5.7+ or MariaDB 10.3+
+
+## Database
+
+Optrion creates two custom tables on activation. It **never modifies** the `wp_options` table schema — only reads from it and renames rows during quarantine.
+
+| Table | Purpose |
+|-------|---------|
+| `{prefix}_options_tracking` | Stores read timestamps, counts, and reader identity for each option |
+| `{prefix}_options_quarantine` | Manages quarantine lifecycle (original name, autoload, expiry, status) |
+
+Both tables are dropped on **uninstall** (not deactivation). Backup files in `wp-content/optrion-backups/` are also removed.
+
+## Export Format
+
+```json
+{
+  "version": "1.0.0",
+  "exported_at": "2026-04-05T12:00:00+09:00",
+  "site_url": "https://example.com",
+  "wp_version": "6.8",
+  "options": [
+    {
+      "option_name": "some_plugin_setting",
+      "option_value": "serialized_or_raw_value",
+      "autoload": "yes",
+      "tracking": {
+        "last_read_at": "2025-12-01 10:30:00",
+        "read_count": 42,
+        "last_reader": "some-plugin",
+        "reader_type": "plugin"
+      },
+      "score": {
+        "total": 75,
+        "reasons": [...]
+      }
+    }
+  ]
+}
+```
+
+## Security
+
+- All operations require `manage_options` capability
+- REST API uses WordPress nonce authentication (`X-WP-Nonce`)
+- All database queries use `$wpdb->prepare()`
+- Backup directory is protected with `.htaccess`
+- Import validates JSON schema, version field, and option name characters
+- ~60 core WordPress options are hardcoded as protected and cannot be deleted or quarantined
+
+## Performance
+
+| Concern | Mitigation |
+|---------|------------|
+| `debug_backtrace` cost | Limited to 15 frames with `IGNORE_ARGS` |
+| Per-request DB writes | Buffered in memory, single upsert at `shutdown` |
+| Non-autoload option hooks | Registered only on `admin_init`, not on frontend |
+| Large option tables | Paginated REST API (default 50/page), on-demand scoring |
+| Tracking overhead | Controlled via transient flag, optional sampling rate (1–100%) |
+
+## FAQ
+
+**Does Optrion slow down my site?**
+
+No. Tracking is off by default and only activates for short windows when an admin visits the dashboard. Even when active, all DB writes are batched into a single query at shutdown. Frontend performance is unaffected.
+
+**What happens if I quarantine something important?**
+
+The option is renamed, not deleted. Click "Restore" in the admin panel or run `wp optrion quarantine restore <name>` to bring it back instantly. If you do nothing, it auto-restores after the quarantine period expires.
+
+**Is it safe to delete options with a score of 80+?**
+
+Scores above 80 typically mean the owning plugin is deactivated/deleted AND the option hasn't been read in months. It's very likely safe. Optrion always creates a JSON backup before any deletion, so you can restore via import if needed.
+
+**Does it work with multisite?**
+
+Currently single-site only. Multisite support (`wp_sitemeta`) is planned.
+
+## Contributing
+
+Contributions are welcome. Please open an issue first to discuss what you'd like to change.
+
+```bash
+# Development setup
+git clone https://github.com/your-username/optrion.git
+cd optrion
+composer install
+npm install
+npm run dev    # watch mode for React admin UI
+
+# Run tests
+composer test
+```
+
+## License
+
+GPL-2.0-or-later — see [LICENSE](LICENSE) for details.

--- a/assets/optrion-icon.svg
+++ b/assets/optrion-icon.svg
@@ -1,0 +1,15 @@
+<svg width="72" height="72" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+  <!-- Ring -->
+  <circle cx="36" cy="36" r="32" fill="none" stroke="#1e3050" stroke-width="1.8"/>
+  <!-- Connecting line -->
+  <line x1="20" y1="21" x2="52" y2="51" stroke="#2a4a7a" stroke-width="0.8" stroke-linecap="round"/>
+  <!-- Safe (blue) -->
+  <circle cx="20" cy="21" r="5" fill="#4d8fe6"/>
+  <circle cx="20" cy="21" r="8.5" fill="none" stroke="#4d8fe6" stroke-width="0.5" opacity="0.25"/>
+  <!-- Caution (amber) -->
+  <circle cx="36" cy="36" r="5.5" fill="#e8993e"/>
+  <circle cx="36" cy="36" r="9" fill="none" stroke="#e8993e" stroke-width="0.5" opacity="0.25"/>
+  <!-- Remove (red) -->
+  <circle cx="52" cy="51" r="5" fill="#e05555"/>
+  <circle cx="52" cy="51" r="8.5" fill="none" stroke="#e05555" stroke-width="0.5" opacity="0.25"/>
+</svg>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "mt8/optrion",
+    "description": "Track, score, quarantine, and clean orphaned options in your WordPress database.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=7.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6",
+        "yoast/phpunit-polyfills": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Optrion\\": "includes/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Optrion\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "lint": "phpcs",
+        "lint:fix": "phpcbf"
+    }
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Optrion main plugin bootstrap class.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main plugin class.
+ */
+final class Plugin {
+
+	/**
+	 * Boot the plugin.
+	 *
+	 * Registers hooks and loads modules.
+	 */
+	public static function boot(): void {
+		load_plugin_textdomain( 'optrion', false, dirname( plugin_basename( OPTRION_FILE ) ) . '/languages' );
+	}
+
+	/**
+	 * Activation hook callback.
+	 *
+	 * Creates custom tables and schedules cron.
+	 */
+	public static function activate(): void {
+		// Implemented in a later task (#8).
+	}
+
+	/**
+	 * Deactivation hook callback.
+	 *
+	 * Unschedules cron. Does not drop tables.
+	 */
+	public static function deactivate(): void {
+		// Implemented in a later task.
+	}
+}

--- a/optrion.php
+++ b/optrion.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Plugin Name:       Optrion
+ * Plugin URI:        https://github.com/mt8/optrion
+ * Description:       Track, score, quarantine, and clean orphaned options in your WordPress database.
+ * Version:           0.1.0
+ * Requires at least: 5.8
+ * Requires PHP:      7.4
+ * Author:            mt8
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       optrion
+ * Domain Path:       /languages
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'OPTRION_VERSION', '0.1.0' );
+define( 'OPTRION_FILE', __FILE__ );
+define( 'OPTRION_DIR', plugin_dir_path( __FILE__ ) );
+define( 'OPTRION_URL', plugin_dir_url( __FILE__ ) );
+
+$optrion_autoload = OPTRION_DIR . 'vendor/autoload.php';
+if ( is_readable( $optrion_autoload ) ) {
+	require_once $optrion_autoload;
+}
+
+require_once OPTRION_DIR . 'includes/class-plugin.php';
+
+register_activation_hook( __FILE__, array( \Optrion\Plugin::class, 'activate' ) );
+register_deactivation_hook( __FILE__, array( \Optrion\Plugin::class, 'deactivate' ) );
+
+add_action( 'plugins_loaded', array( \Optrion\Plugin::class, 'boot' ) );

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "optrion",
+  "version": "0.1.0",
+  "description": "Track, score, quarantine, and clean orphaned options in your WordPress database.",
+  "private": true,
+  "license": "GPL-2.0-or-later",
+  "scripts": {
+    "env": "wp-env",
+    "env:start": "wp-env start",
+    "env:stop": "wp-env stop",
+    "env:clean": "wp-env clean all"
+  },
+  "devDependencies": {
+    "@wordpress/env": "^10.0.0"
+  }
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Optrion uninstall script.
+ *
+ * @package Optrion
+ */
+
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+// Full cleanup logic will be implemented in a later task.


### PR DESCRIPTION
## Summary
- optrion.php メインブートストラップを追加
- PSR-4 autoload (Optrion\) の composer.json
- package.json (wp-env 依存のみ)
- .gitignore 拡充、uninstall.php スタブ

Closes #1

## Test plan
- [ ] 後続PR (#2 wp-env, #3 phpcs, #4 phpunit) で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)