### PR TITLE
wp-envローカル環境セットアップ

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,20 @@
+{
+	"core": null,
+	"phpVersion": "8.1",
+	"plugins": [ "." ],
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"SCRIPT_DEBUG": true
+	},
+	"mappings": {
+		"wp-cli.local.yml": "./.wp-env/wp-cli.local.yml"
+	},
+	"env": {
+		"tests": {
+			"config": {
+				"WP_DEBUG": true
+			}
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -277,13 +277,17 @@ Contributions are welcome. Please open an issue first to discuss what you'd like
 
 ```bash
 # Development setup
-git clone https://github.com/your-username/optrion.git
+git clone https://github.com/mt8/optrion.git
 cd optrion
 composer install
 npm install
-npm run dev    # watch mode for React admin UI
 
-# Run tests
+# Start local WordPress (Docker required)
+npm run env:start        # http://localhost:8888  (admin / password)
+npm run env:stop
+npm run env:clean        # reset both dev & tests environments
+
+# Run tests (inside the tests-wordpress container)
 composer test
 ```
 


### PR DESCRIPTION
## Summary
- .wp-env.json を追加 (dev + tests 環境)
- README に wp-env 起動手順を追記

Closes #2

## Test plan
- [ ] \`npm install && npm run env:start\` で http://localhost:8888 が起動する
- [ ] tests 環境 (:8889) が起動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)