### PR TITLE
PHPUnit (wp-env統合) セットアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "env": "wp-env",
     "env:start": "wp-env start",
     "env:stop": "wp-env stop",
-    "env:clean": "wp-env clean all"
+    "env:clean": "wp-env clean all",
+    "test": "wp-env run tests-cli --env-cwd=wp-content/plugins/optrion composer test",
+    "lint": "wp-env run cli --env-cwd=wp-content/plugins/optrion composer lint"
   },
   "devDependencies": {
     "@wordpress/env": "^10.0.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,7 @@
 	<file>optrion.php</file>
 	<file>uninstall.php</file>
 	<file>includes/</file>
+	<file>tests/</file>
 
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	beStrictAboutCoversAnnotation="true"
+	beStrictAboutOutputDuringTests="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	beStrictAboutTodoAnnotatedTests="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="true"
+	failOnRisky="true"
+	failOnWarning="true"
+	verbose="true"
+	>
+	<testsuites>
+		<testsuite name="optrion">
+			<directory suffix=".php">tests/</directory>
+			<exclude>tests/bootstrap.php</exclude>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
+			<directory suffix=".php">includes/</directory>
+			<file>optrion.php</file>
+		</include>
+	</coverage>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * PHPUnit bootstrap for the Optrion test suite.
+ *
+ * Uses the WordPress test harness mounted inside the wp-env tests container
+ * (/wordpress-phpunit/includes/).
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals, WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+
+$optrion_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( false === $optrion_tests_dir ) {
+	$optrion_tests_dir = '/wordpress-phpunit';
+}
+
+if ( ! file_exists( $optrion_tests_dir . '/includes/functions.php' ) ) {
+	fwrite( STDERR, "Could not find WordPress test suite at {$optrion_tests_dir}.\n" );
+	fwrite( STDERR, "Run tests via: npx wp-env run tests-cli --env-cwd=wp-content/plugins/optrion composer test\n" );
+	exit( 1 );
+}
+
+require_once $optrion_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+function optrion_manually_load_plugin(): void {
+	require dirname( __DIR__ ) . '/optrion.php';
+}
+tests_add_filter( 'muplugins_loaded', 'optrion_manually_load_plugin' );
+
+require $optrion_tests_dir . '/includes/bootstrap.php';
+
+// phpcs:enable

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Smoke tests for the plugin bootstrap.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion\Tests;
+
+use WP_UnitTestCase;
+
+/**
+ * Basic bootstrap smoke test.
+ *
+ * @coversNothing
+ */
+class PluginBootstrapTest extends WP_UnitTestCase {
+
+	/**
+	 * The plugin defines its version constant.
+	 */
+	public function test_version_constant_is_defined(): void {
+		$this->assertTrue( defined( 'OPTRION_VERSION' ) );
+		$this->assertIsString( OPTRION_VERSION );
+	}
+
+	/**
+	 * The main class is loaded via autoload.
+	 */
+	public function test_plugin_class_autoloaded(): void {
+		$this->assertTrue( class_exists( \Optrion\Plugin::class ) );
+	}
+}


### PR DESCRIPTION
## Summary
- phpunit.xml.dist 追加
- tests/bootstrap.php で WP_TESTS_DIR を自動検出
- スモークテスト 2件
- \`npm test\` で wp-env tests-cli 経由で実行

Closes #4

## Test plan
- [x] composer lint 通過
- [ ] \`npm run env:start && npm test\` が通る (Docker環境)

🤖 Generated with [Claude Code](https://claude.com/claude-code)