### PR TITLE
feat: DB schema installer for tracking and quarantine tables (#8)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -23,6 +23,7 @@ final class Plugin {
 	 */
 	public static function boot(): void {
 		load_plugin_textdomain( 'optrion', false, dirname( plugin_basename( OPTRION_FILE ) ) . '/languages' );
+		Schema::maybe_upgrade();
 	}
 
 	/**
@@ -31,7 +32,7 @@ final class Plugin {
 	 * Creates custom tables and schedules cron.
 	 */
 	public static function activate(): void {
-		// Implemented in a later task (#8).
+		Schema::install();
 	}
 
 	/**

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -95,6 +95,13 @@ final class Schema {
 		dbDelta( $quarantine_sql );
 
 		update_option( self::VERSION_OPTION, self::DB_VERSION, false );
+
+		/**
+		 * Fires after the Optrion schema has been installed or refreshed.
+		 *
+		 * @param string $db_version The schema version that was installed.
+		 */
+		do_action( 'optrion_schema_installed', self::DB_VERSION );
 	}
 
 	/**

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Schema installer for Optrion custom tables.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages creation and upgrade of the plugin's custom tables.
+ *
+ * See docs/DESIGN.md §3 for the schema contract.
+ */
+final class Schema {
+
+	/**
+	 * Database schema version.
+	 *
+	 * Bump this whenever a table definition changes.
+	 */
+	public const DB_VERSION = '1.0.0';
+
+	/**
+	 * Option key that stores the installed DB version.
+	 */
+	public const VERSION_OPTION = 'optrion_db_version';
+
+	/**
+	 * Returns the tracking table name (with site prefix).
+	 */
+	public static function tracking_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'options_tracking';
+	}
+
+	/**
+	 * Returns the quarantine table name (with site prefix).
+	 */
+	public static function quarantine_table(): string {
+		global $wpdb;
+		return $wpdb->prefix . 'options_quarantine';
+	}
+
+	/**
+	 * Runs dbDelta to create or update all custom tables.
+	 *
+	 * Safe to call repeatedly — dbDelta only issues DDL for differences.
+	 */
+	public static function install(): void {
+		global $wpdb;
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$charset_collate = $wpdb->get_charset_collate();
+		$tracking        = self::tracking_table();
+		$quarantine      = self::quarantine_table();
+
+		$tracking_sql = "CREATE TABLE {$tracking} (
+			option_name varchar(191) NOT NULL,
+			last_read_at datetime NULL DEFAULT NULL,
+			read_count bigint(20) unsigned NOT NULL DEFAULT 0,
+			last_reader varchar(255) NOT NULL DEFAULT '',
+			reader_type varchar(20) NOT NULL DEFAULT 'unknown',
+			first_seen datetime NOT NULL,
+			PRIMARY KEY  (option_name),
+			KEY last_read_at (last_read_at),
+			KEY reader_type (reader_type),
+			KEY read_count (read_count)
+		) {$charset_collate};";
+
+		$quarantine_sql = "CREATE TABLE {$quarantine} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			original_name varchar(191) NOT NULL,
+			original_autoload varchar(20) NOT NULL DEFAULT 'yes',
+			quarantined_at datetime NOT NULL,
+			expires_at datetime NOT NULL,
+			quarantined_by bigint(20) unsigned NOT NULL DEFAULT 0,
+			score_at_quarantine int(11) NOT NULL DEFAULT 0,
+			status varchar(20) NOT NULL DEFAULT 'active',
+			restored_at datetime NULL DEFAULT NULL,
+			deleted_at datetime NULL DEFAULT NULL,
+			notes text NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY original_name (original_name),
+			KEY status (status),
+			KEY expires_at (expires_at)
+		) {$charset_collate};";
+
+		dbDelta( $tracking_sql );
+		dbDelta( $quarantine_sql );
+
+		update_option( self::VERSION_OPTION, self::DB_VERSION, false );
+	}
+
+	/**
+	 * Checks the stored DB version and reinstalls the schema if it is out of date.
+	 *
+	 * Intended to run on plugin load so that schema drift after a plugin update
+	 * is healed without requiring the user to deactivate/reactivate.
+	 */
+	public static function maybe_upgrade(): void {
+		$installed = get_option( self::VERSION_OPTION );
+		if ( self::DB_VERSION === $installed ) {
+			return;
+		}
+		self::install();
+	}
+}

--- a/optrion.php
+++ b/optrion.php
@@ -29,6 +29,7 @@ if ( is_readable( $optrion_autoload ) ) {
 	require_once $optrion_autoload;
 }
 
+require_once OPTRION_DIR . 'includes/class-schema.php';
 require_once OPTRION_DIR . 'includes/class-plugin.php';
 
 register_activation_hook( __FILE__, array( \Optrion\Plugin::class, 'activate' ) );

--- a/tests/test-schema.php
+++ b/tests/test-schema.php
@@ -20,17 +20,6 @@ use WP_UnitTestCase;
 class SchemaTest extends WP_UnitTestCase {
 
 	/**
-	 * Ensures a clean slate by dropping the plugin tables before each test.
-	 */
-	public function set_up(): void {
-		parent::set_up();
-		global $wpdb;
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . Schema::tracking_table() ); // phpcs:ignore WordPress.DB
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . Schema::quarantine_table() ); // phpcs:ignore WordPress.DB
-		delete_option( Schema::VERSION_OPTION );
-	}
-
-	/**
 	 * The installer creates both custom tables.
 	 */
 	public function test_install_creates_tables(): void {
@@ -59,27 +48,55 @@ class SchemaTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The upgrader installs tables when the version option is missing.
+	 * The upgrader runs install when the version option is missing.
 	 */
 	public function test_maybe_upgrade_installs_when_missing(): void {
-		$this->assertFalse( $this->table_exists( Schema::tracking_table() ) );
+		delete_option( Schema::VERSION_OPTION );
+		$fired = $this->track_install_action();
+
 		Schema::maybe_upgrade();
-		$this->assertTrue( $this->table_exists( Schema::tracking_table() ) );
-		$this->assertTrue( $this->table_exists( Schema::quarantine_table() ) );
+
+		$this->assertSame( 1, $fired(), 'install() should fire once when version is missing' );
+		$this->assertSame( Schema::DB_VERSION, get_option( Schema::VERSION_OPTION ) );
+	}
+
+	/**
+	 * The upgrader runs install when the stored version is stale.
+	 */
+	public function test_maybe_upgrade_installs_when_stale(): void {
+		update_option( Schema::VERSION_OPTION, '0.0.0-old' );
+		$fired = $this->track_install_action();
+
+		Schema::maybe_upgrade();
+
+		$this->assertSame( 1, $fired(), 'install() should fire once when version is stale' );
+		$this->assertSame( Schema::DB_VERSION, get_option( Schema::VERSION_OPTION ) );
 	}
 
 	/**
 	 * The upgrader is a no-op when the stored version matches.
 	 */
 	public function test_maybe_upgrade_skips_when_current(): void {
-		Schema::install();
-		// Drop a table to detect whether maybe_upgrade reinstalled it.
-		global $wpdb;
-		$wpdb->query( 'DROP TABLE IF EXISTS ' . Schema::tracking_table() ); // phpcs:ignore WordPress.DB
-		$this->assertFalse( $this->table_exists( Schema::tracking_table() ) );
+		update_option( Schema::VERSION_OPTION, Schema::DB_VERSION );
+		$fired = $this->track_install_action();
 
 		Schema::maybe_upgrade();
-		$this->assertFalse( $this->table_exists( Schema::tracking_table() ) );
+
+		$this->assertSame( 0, $fired(), 'install() should not fire when version matches' );
+	}
+
+	/**
+	 * Adds a temporary action listener and returns a closure yielding the call count.
+	 */
+	private function track_install_action(): callable {
+		$count    = 0;
+		$listener = static function () use ( &$count ): void {
+			++$count;
+		};
+		add_action( 'optrion_schema_installed', $listener );
+		return static function () use ( &$count ): int {
+			return $count;
+		};
 	}
 
 	/**

--- a/tests/test-schema.php
+++ b/tests/test-schema.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Schema installer tests.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion\Tests;
+
+use Optrion\Schema;
+use WP_UnitTestCase;
+
+/**
+ * Verifies that Schema::install() creates the expected custom tables.
+ *
+ * @coversDefaultClass \Optrion\Schema
+ */
+class SchemaTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensures a clean slate by dropping the plugin tables before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		global $wpdb;
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . Schema::tracking_table() ); // phpcs:ignore WordPress.DB
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . Schema::quarantine_table() ); // phpcs:ignore WordPress.DB
+		delete_option( Schema::VERSION_OPTION );
+	}
+
+	/**
+	 * The installer creates both custom tables.
+	 */
+	public function test_install_creates_tables(): void {
+		Schema::install();
+
+		$this->assertTrue( $this->table_exists( Schema::tracking_table() ) );
+		$this->assertTrue( $this->table_exists( Schema::quarantine_table() ) );
+	}
+
+	/**
+	 * The installer records the DB version.
+	 */
+	public function test_install_stores_db_version(): void {
+		Schema::install();
+		$this->assertSame( Schema::DB_VERSION, get_option( Schema::VERSION_OPTION ) );
+	}
+
+	/**
+	 * The installer is idempotent and can be re-run safely.
+	 */
+	public function test_install_is_idempotent(): void {
+		Schema::install();
+		Schema::install();
+		$this->assertTrue( $this->table_exists( Schema::tracking_table() ) );
+		$this->assertTrue( $this->table_exists( Schema::quarantine_table() ) );
+	}
+
+	/**
+	 * The upgrader installs tables when the version option is missing.
+	 */
+	public function test_maybe_upgrade_installs_when_missing(): void {
+		$this->assertFalse( $this->table_exists( Schema::tracking_table() ) );
+		Schema::maybe_upgrade();
+		$this->assertTrue( $this->table_exists( Schema::tracking_table() ) );
+		$this->assertTrue( $this->table_exists( Schema::quarantine_table() ) );
+	}
+
+	/**
+	 * The upgrader is a no-op when the stored version matches.
+	 */
+	public function test_maybe_upgrade_skips_when_current(): void {
+		Schema::install();
+		// Drop a table to detect whether maybe_upgrade reinstalled it.
+		global $wpdb;
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . Schema::tracking_table() ); // phpcs:ignore WordPress.DB
+		$this->assertFalse( $this->table_exists( Schema::tracking_table() ) );
+
+		Schema::maybe_upgrade();
+		$this->assertFalse( $this->table_exists( Schema::tracking_table() ) );
+	}
+
+	/**
+	 * Checks whether a table exists via SHOW TABLES.
+	 *
+	 * @param string $table Fully-qualified table name.
+	 */
+	private function table_exists( string $table ): bool {
+		global $wpdb;
+		$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ); // phpcs:ignore WordPress.DB
+		return $found === $table;
+	}
+}


### PR DESCRIPTION
## Summary
- Add \`Optrion\Schema\` installer that owns the two custom tables per docs/DESIGN.md §3 / §4.5
- \`{prefix}_options_tracking\` — per-option read stats (PK option_name, indexes on last_read_at / reader_type / read_count)
- \`{prefix}_options_quarantine\` — soft-delete manifest (unique key original_name, indexes on status / expires_at)
- Wired into the activation hook and \`plugins_loaded\`; stores \`optrion_db_version\` and auto-heals via \`maybe_upgrade()\` when the stored version drifts
- PHPUnit coverage for install, idempotency, missing-version install, and version-gated skip

Closes #8

## Test plan
- [ ] CI PHPUnit (PHP 7.4 / 8.1 / 8.2, WP latest & 6.3) passes
- [ ] Activate plugin on a fresh site, verify both tables exist with expected columns/indexes
- [ ] Bump \`Schema::DB_VERSION\`, reload, confirm tables still valid (dbDelta is idempotent)