### PR TITLE
feat: known WordPress core options registry (#9)

### DIFF
--- a/includes/class-core-options.php
+++ b/includes/class-core-options.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Known WordPress core option names.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Static registry of option names that WordPress core itself manages.
+ *
+ * The list is used by the Scorer (see docs/DESIGN.md §4.2) to classify
+ * an option as `owner=core`, and by the Cleaner / Quarantine modules to
+ * lock out destructive operations on core-owned rows.
+ *
+ * Sourced from the WordPress Codex "Option Reference" page; entries are
+ * the stable option names registered by WordPress core on a fresh install.
+ */
+final class CoreOptions {
+
+	/**
+	 * Canonical list of core option names.
+	 *
+	 * Entries are deliberately lowercase and kept sorted alphabetically to
+	 * make review easy. Transients and per-theme `theme_mods_*` entries are
+	 * deliberately excluded — those are dynamic names and need a different
+	 * matcher.
+	 *
+	 * @var string[]
+	 */
+	public const LIST = array(
+		'active_plugins',
+		'admin_email',
+		'admin_email_lifespan',
+		'auto_plugin_theme_update_emails',
+		'auto_update_core_dev',
+		'auto_update_core_major',
+		'auto_update_core_minor',
+		'avatar_default',
+		'avatar_rating',
+		'blacklist_keys',
+		'blog_charset',
+		'blog_public',
+		'blogdescription',
+		'blogname',
+		'category_base',
+		'close_comments_days_old',
+		'close_comments_for_old_posts',
+		'comment_max_links',
+		'comment_moderation',
+		'comment_order',
+		'comment_previously_approved',
+		'comment_registration',
+		'comments_notify',
+		'comments_per_page',
+		'cron',
+		'current_theme',
+		'date_format',
+		'db_version',
+		'default_category',
+		'default_comment_status',
+		'default_comments_page',
+		'default_email_category',
+		'default_link_category',
+		'default_ping_status',
+		'default_pingback_flag',
+		'default_post_format',
+		'default_role',
+		'disallowed_keys',
+		'fresh_site',
+		'gmt_offset',
+		'hack_file',
+		'home',
+		'html_type',
+		'image_default_align',
+		'image_default_link_type',
+		'image_default_size',
+		'initial_db_version',
+		'large_size_h',
+		'large_size_w',
+		'link_manager_enabled',
+		'links_updated_date_format',
+		'mailserver_login',
+		'mailserver_pass',
+		'mailserver_port',
+		'mailserver_url',
+		'medium_large_size_h',
+		'medium_large_size_w',
+		'medium_size_h',
+		'medium_size_w',
+		'moderation_keys',
+		'moderation_notify',
+		'nav_menu_options',
+		'page_comments',
+		'page_for_posts',
+		'page_on_front',
+		'permalink_structure',
+		'ping_sites',
+		'posts_per_page',
+		'posts_per_rss',
+		'recently_activated',
+		'recently_edited',
+		'require_name_email',
+		'rewrite_rules',
+		'rss_use_excerpt',
+		'show_avatars',
+		'show_comments_cookies_opt_in',
+		'show_on_front',
+		'sidebars_widgets',
+		'site_icon',
+		'siteurl',
+		'start_of_week',
+		'sticky_posts',
+		'stylesheet',
+		'tag_base',
+		'template',
+		'thread_comments',
+		'thread_comments_depth',
+		'thumbnail_crop',
+		'thumbnail_size_h',
+		'thumbnail_size_w',
+		'time_format',
+		'timezone_string',
+		'uninstall_plugins',
+		'upload_path',
+		'upload_url_path',
+		'uploads_use_yearmonth_folders',
+		'use_balancetags',
+		'use_smilies',
+		'use_trackback',
+		'users_can_register',
+		'widget_categories',
+		'widget_rss',
+		'widget_text',
+		'wp_force_deactivated_plugins',
+		'wp_page_for_privacy_policy',
+		'wp_user_roles',
+	);
+
+	/**
+	 * Returns the canonical core option list.
+	 *
+	 * Wrapped in a filter so that site owners can add custom "never touch"
+	 * entries (for example, options from must-use plugins they treat as core).
+	 *
+	 * @return string[]
+	 */
+	public static function all(): array {
+		/**
+		 * Filters the list of option names treated as WordPress core.
+		 *
+		 * @param string[] $list Canonical option names considered core.
+		 */
+		$list = apply_filters( 'optrion_core_options', self::LIST );
+
+		return array_values( array_unique( array_map( 'strval', $list ) ) );
+	}
+
+	/**
+	 * Checks whether the given option name is in the core list.
+	 *
+	 * @param string $option_name Raw option_name from wp_options.
+	 */
+	public static function contains( string $option_name ): bool {
+		return in_array( $option_name, self::all(), true );
+	}
+}

--- a/optrion.php
+++ b/optrion.php
@@ -30,6 +30,7 @@ if ( is_readable( $optrion_autoload ) ) {
 }
 
 require_once OPTRION_DIR . 'includes/class-schema.php';
+require_once OPTRION_DIR . 'includes/class-core-options.php';
 require_once OPTRION_DIR . 'includes/class-plugin.php';
 
 register_activation_hook( __FILE__, array( \Optrion\Plugin::class, 'activate' ) );

--- a/tests/test-core-options.php
+++ b/tests/test-core-options.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Core options registry tests.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion\Tests;
+
+use Optrion\CoreOptions;
+use WP_UnitTestCase;
+
+/**
+ * Verifies behavior of the known core options registry.
+ *
+ * @coversDefaultClass \Optrion\CoreOptions
+ */
+class CoreOptionsTest extends WP_UnitTestCase {
+
+	/**
+	 * The canonical list covers the essential core options.
+	 */
+	public function test_list_contains_essential_core_names(): void {
+		$essentials = array(
+			'siteurl',
+			'home',
+			'blogname',
+			'active_plugins',
+			'template',
+			'stylesheet',
+			'cron',
+			'rewrite_rules',
+			'permalink_structure',
+			'db_version',
+		);
+
+		foreach ( $essentials as $name ) {
+			$this->assertTrue( CoreOptions::contains( $name ), "Expected '{$name}' in core list." );
+		}
+	}
+
+	/**
+	 * Unknown option names are not flagged as core.
+	 */
+	public function test_contains_returns_false_for_plugin_options(): void {
+		$this->assertFalse( CoreOptions::contains( 'woocommerce_settings' ) );
+		$this->assertFalse( CoreOptions::contains( 'my_custom_plugin_setting' ) );
+		$this->assertFalse( CoreOptions::contains( '' ) );
+	}
+
+	/**
+	 * The list is non-trivial (guards against accidental truncation).
+	 */
+	public function test_list_has_expected_size(): void {
+		$this->assertGreaterThanOrEqual( 60, count( CoreOptions::all() ) );
+	}
+
+	/**
+	 * The list is deduplicated.
+	 */
+	public function test_list_is_unique(): void {
+		$list = CoreOptions::all();
+		$this->assertSame( count( $list ), count( array_unique( $list ) ) );
+	}
+
+	/**
+	 * Custom entries injected via filter are honored.
+	 */
+	public function test_filter_can_extend_list(): void {
+		$filter = static function ( array $names ): array {
+			$names[] = 'my_mu_plugin_sentinel';
+			return $names;
+		};
+		add_filter( 'optrion_core_options', $filter );
+
+		try {
+			$this->assertTrue( CoreOptions::contains( 'my_mu_plugin_sentinel' ) );
+		} finally {
+			remove_filter( 'optrion_core_options', $filter );
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add \`Optrion\CoreOptions\` registry used to classify option_name rows as WP core (owner lock-out, Scorer rule 4 per docs/DESIGN.md §4.2)
- ~100 canonical option names sourced from the Codex Option Reference
- \`optrion_core_options\` filter lets sites extend the list (e.g. must-use plugin state)
- PHPUnit coverage: essentials present, plugin names rejected, list ≥60 and unique, filter extensibility

Closes #9

## Test plan
- [ ] CI PHPUnit green across all matrix entries
- [ ] Spot-check list entries against the Codex Option Reference