### PR TITLE
feat: option read tracker with alloptions hook and shutdown flush (#10)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -24,6 +24,7 @@ final class Plugin {
 	public static function boot(): void {
 		load_plugin_textdomain( 'optrion', false, dirname( plugin_basename( OPTRION_FILE ) ) . '/languages' );
 		Schema::maybe_upgrade();
+		Tracker::boot();
 	}
 
 	/**

--- a/includes/class-tracker.php
+++ b/includes/class-tracker.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * Read-tracking module.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Observes `get_option()` reads and records per-option usage statistics.
+ *
+ * Behavior is described in docs/DESIGN.md §4.1:
+ *
+ * - Autoload options are captured in bulk via the `alloptions` filter.
+ * - Non-autoload options are captured by dynamically registered
+ *   `option_{$name}` filters on admin_init.
+ * - All writes are buffered in memory and flushed once at shutdown.
+ * - A transient gate limits tracking to admin traffic (10-minute window)
+ *   and an optional sampling rate reduces load further.
+ */
+final class Tracker {
+
+	/**
+	 * Transient key holding the "tracking is active" flag.
+	 */
+	public const ENABLE_TRANSIENT = 'optrion_tracking_enabled';
+
+	/**
+	 * Option key holding the sampling rate (0-100).
+	 */
+	public const SAMPLING_OPTION = 'optrion_sampling_rate';
+
+	/**
+	 * Duration of the admin-triggered tracking window (seconds).
+	 */
+	public const WINDOW_SECONDS = 600;
+
+	/**
+	 * In-memory per-request buffer keyed by option_name.
+	 *
+	 * @var array<string,array{count:int,last:string,reader:string,type:string}>
+	 */
+	private static array $buffer = array();
+
+	/**
+	 * True once `boot()` has wired hooks for this request.
+	 *
+	 * @var bool
+	 */
+	private static bool $booted = false;
+
+	/**
+	 * True if sampling allowed this request to be tracked.
+	 *
+	 * @var bool
+	 */
+	private static bool $request_sampled = false;
+
+	/**
+	 * Registers tracking hooks for the current request.
+	 *
+	 * Safe to call once on `plugins_loaded`. The individual filter callbacks
+	 * short-circuit if tracking is not active so that inactive sites pay only
+	 * the cost of a transient lookup.
+	 */
+	public static function boot(): void {
+		if ( self::$booted ) {
+			return;
+		}
+		self::$booted = true;
+
+		// Admin visits renew the tracking window regardless of sampling.
+		add_action( 'admin_init', array( self::class, 'refresh_window' ) );
+
+		if ( ! self::should_track_this_request() ) {
+			return;
+		}
+		self::$request_sampled = true;
+
+		add_filter( 'alloptions', array( self::class, 'record_alloptions' ), 999 );
+		add_action( 'admin_init', array( self::class, 'register_non_autoload_hooks' ), 999 );
+		add_action( 'shutdown', array( self::class, 'flush' ), 0 );
+	}
+
+	/**
+	 * Resets per-request state. Intended for tests.
+	 */
+	public static function reset_for_test(): void {
+		self::$buffer          = array();
+		self::$booted          = false;
+		self::$request_sampled = false;
+	}
+
+	/**
+	 * Renews the admin-presence transient so tracking runs for WINDOW_SECONDS.
+	 */
+	public static function refresh_window(): void {
+		set_transient( self::ENABLE_TRANSIENT, 1, self::WINDOW_SECONDS );
+	}
+
+	/**
+	 * Decides whether this request is eligible for tracking.
+	 */
+	public static function should_track_this_request(): bool {
+		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+			return false;
+		}
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return false;
+		}
+		if ( ! get_transient( self::ENABLE_TRANSIENT ) ) {
+			return false;
+		}
+
+		$rate = (int) get_option( self::SAMPLING_OPTION, 100 );
+		if ( $rate >= 100 ) {
+			return true;
+		}
+		if ( $rate <= 0 ) {
+			return false;
+		}
+
+		return wp_rand( 1, 100 ) <= $rate;
+	}
+
+	/**
+	 * Filter callback for `alloptions`: records every autoload option name.
+	 *
+	 * @param mixed $alloptions The raw `alloptions` payload; normally an array.
+	 * @return mixed The payload unchanged.
+	 */
+	public static function record_alloptions( $alloptions ) {
+		if ( ! is_array( $alloptions ) ) {
+			return $alloptions;
+		}
+		$reader = self::identify_caller();
+		$now    = current_time( 'mysql', true );
+		foreach ( array_keys( $alloptions ) as $name ) {
+			self::buffer_record( (string) $name, $reader, $now );
+		}
+		return $alloptions;
+	}
+
+	/**
+	 * Registers `option_{$name}` filters for every non-autoload option.
+	 *
+	 * Runs on admin_init so that autoload-flagged rows (already covered by
+	 * the `alloptions` filter) are not double-registered.
+	 */
+	public static function register_non_autoload_hooks(): void {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$names = $wpdb->get_col(
+			"SELECT option_name FROM {$wpdb->options} WHERE autoload NOT IN ('yes','on','auto','auto-on')"
+		);
+		if ( ! is_array( $names ) ) {
+			return;
+		}
+		foreach ( $names as $name ) {
+			$name = (string) $name;
+			add_filter(
+				"option_{$name}",
+				static function ( $value ) use ( $name ) {
+					$reader = Tracker::identify_caller();
+					Tracker::buffer_record( $name, $reader, current_time( 'mysql', true ) );
+					return $value;
+				},
+				999
+			);
+		}
+	}
+
+	/**
+	 * Records a single read into the in-memory buffer.
+	 *
+	 * @param string                         $name   Option name.
+	 * @param array{type:string,slug:string} $reader Reader classification.
+	 * @param string                         $now    MySQL-formatted UTC timestamp.
+	 */
+	public static function buffer_record( string $name, array $reader, string $now ): void {
+		if ( ! isset( self::$buffer[ $name ] ) ) {
+			self::$buffer[ $name ] = array(
+				'count'  => 0,
+				'last'   => $now,
+				'reader' => $reader['slug'],
+				'type'   => $reader['type'],
+			);
+		}
+		++self::$buffer[ $name ]['count'];
+		self::$buffer[ $name ]['last']   = $now;
+		self::$buffer[ $name ]['reader'] = $reader['slug'];
+		self::$buffer[ $name ]['type']   = $reader['type'];
+	}
+
+	/**
+	 * Flushes the buffer into the tracking table as a single upsert.
+	 */
+	public static function flush(): void {
+		if ( empty( self::$buffer ) ) {
+			return;
+		}
+		global $wpdb;
+		$table = Schema::tracking_table();
+
+		$placeholders = array();
+		$values       = array();
+		foreach ( self::$buffer as $name => $entry ) {
+			$placeholders[] = '(%s, %s, %d, %s, %s, %s)';
+			$values[]       = $name;
+			$values[]       = $entry['last'];
+			$values[]       = $entry['count'];
+			$values[]       = $entry['reader'];
+			$values[]       = $entry['type'];
+			$values[]       = $entry['last'];
+		}
+
+		$sql = "INSERT INTO {$table}"
+			. ' (option_name, last_read_at, read_count, last_reader, reader_type, first_seen) VALUES '
+			. implode( ',', $placeholders )
+			. ' ON DUPLICATE KEY UPDATE'
+			. ' last_read_at = VALUES(last_read_at),'
+			. ' read_count = read_count + VALUES(read_count),'
+			. ' last_reader = VALUES(last_reader),'
+			. ' reader_type = VALUES(reader_type)';
+
+		$wpdb->query( $wpdb->prepare( $sql, $values ) ); // phpcs:ignore WordPress.DB
+
+		self::$buffer = array();
+	}
+
+	/**
+	 * Returns the request-local buffer. Intended for tests.
+	 *
+	 * @return array<string,array{count:int,last:string,reader:string,type:string}>
+	 */
+	public static function buffer_snapshot(): array {
+		return self::$buffer;
+	}
+
+	/**
+	 * Inspects the current PHP backtrace to attribute the caller.
+	 *
+	 * @return array{type:string,slug:string}
+	 */
+	public static function identify_caller(): array {
+		$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 15 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions
+		return self::classify_trace( $trace );
+	}
+
+	/**
+	 * Classifies a backtrace into {type, slug} based on file paths.
+	 *
+	 * Pure function exposed for unit tests.
+	 *
+	 * @param array<int,array{file?:string}> $trace debug_backtrace() output.
+	 * @return array{type:string,slug:string}
+	 */
+	public static function classify_trace( array $trace ): array {
+		$plugins = self::normalize( defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : '' );
+		$mu      = self::normalize( defined( 'WPMU_PLUGIN_DIR' ) ? WPMU_PLUGIN_DIR : '' );
+		$themes  = self::normalize( function_exists( 'get_theme_root' ) ? get_theme_root() : '' );
+		$self    = self::normalize( defined( 'OPTRION_DIR' ) ? OPTRION_DIR : '' );
+
+		foreach ( $trace as $frame ) {
+			if ( empty( $frame['file'] ) ) {
+				continue;
+			}
+			$file = self::normalize( (string) $frame['file'] );
+
+			if ( '' !== $self && self::starts_with( $file, $self ) ) {
+				continue;
+			}
+			if ( '' !== $plugins && self::starts_with( $file, $plugins ) ) {
+				return array(
+					'type' => 'plugin',
+					'slug' => self::extract_slug( $file, $plugins ),
+				);
+			}
+			if ( '' !== $mu && self::starts_with( $file, $mu ) ) {
+				return array(
+					'type' => 'plugin',
+					'slug' => 'mu:' . self::extract_slug( $file, $mu ),
+				);
+			}
+			if ( '' !== $themes && self::starts_with( $file, $themes ) ) {
+				return array(
+					'type' => 'theme',
+					'slug' => self::extract_slug( $file, $themes ),
+				);
+			}
+		}
+
+		return array(
+			'type' => 'core',
+			'slug' => 'wordpress',
+		);
+	}
+
+	/**
+	 * Normalizes a filesystem path to forward slashes with no trailing slash.
+	 *
+	 * @param string $path Filesystem path.
+	 */
+	private static function normalize( string $path ): string {
+		if ( '' === $path ) {
+			return '';
+		}
+		$path = str_replace( '\\', '/', $path );
+		return rtrim( $path, '/' );
+	}
+
+	/**
+	 * Tests whether $haystack begins with $needle (byte-wise).
+	 *
+	 * @param string $haystack Subject.
+	 * @param string $needle   Prefix.
+	 */
+	private static function starts_with( string $haystack, string $needle ): bool {
+		return 0 === strncmp( $haystack, $needle, strlen( $needle ) );
+	}
+
+	/**
+	 * Extracts the first path segment beneath a base directory.
+	 *
+	 * For `/path/to/plugins/foo/bar.php` with base `/path/to/plugins`
+	 * this returns `foo`. Single-file plugins (e.g. `hello.php` directly
+	 * under the base) return the basename without the `.php` extension.
+	 *
+	 * @param string $file Full file path.
+	 * @param string $base Base directory (already normalized).
+	 */
+	private static function extract_slug( string $file, string $base ): string {
+		$rel = ltrim( substr( $file, strlen( $base ) ), '/' );
+		if ( '' === $rel ) {
+			return '';
+		}
+		$slash = strpos( $rel, '/' );
+		if ( false === $slash ) {
+			return preg_replace( '/\.php$/', '', $rel ) ?? $rel;
+		}
+		return substr( $rel, 0, $slash );
+	}
+}

--- a/optrion.php
+++ b/optrion.php
@@ -31,6 +31,7 @@ if ( is_readable( $optrion_autoload ) ) {
 
 require_once OPTRION_DIR . 'includes/class-schema.php';
 require_once OPTRION_DIR . 'includes/class-core-options.php';
+require_once OPTRION_DIR . 'includes/class-tracker.php';
 require_once OPTRION_DIR . 'includes/class-plugin.php';
 
 register_activation_hook( __FILE__, array( \Optrion\Plugin::class, 'activate' ) );

--- a/tests/test-tracker.php
+++ b/tests/test-tracker.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Tracker module tests.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion\Tests;
+
+use Optrion\Schema;
+use Optrion\Tracker;
+use WP_UnitTestCase;
+
+/**
+ * Covers buffering, flushing, and caller classification.
+ *
+ * @coversDefaultClass \Optrion\Tracker
+ */
+class TrackerTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensures request-local state does not bleed across tests.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		Tracker::reset_for_test();
+		Schema::install();
+		delete_transient( Tracker::ENABLE_TRANSIENT );
+		delete_option( Tracker::SAMPLING_OPTION );
+	}
+
+	/**
+	 * Reader residing under WP_PLUGIN_DIR is classified as a plugin.
+	 */
+	public function test_classify_trace_identifies_plugin_caller(): void {
+		$trace  = array(
+			array( 'file' => WP_PLUGIN_DIR . '/woocommerce/includes/class-wc-cart.php' ),
+		);
+		$result = Tracker::classify_trace( $trace );
+		$this->assertSame( 'plugin', $result['type'] );
+		$this->assertSame( 'woocommerce', $result['slug'] );
+	}
+
+	/**
+	 * Reader residing under the theme root is classified as a theme.
+	 */
+	public function test_classify_trace_identifies_theme_caller(): void {
+		$trace  = array(
+			array( 'file' => get_theme_root() . '/twentytwentyfour/functions.php' ),
+		);
+		$result = Tracker::classify_trace( $trace );
+		$this->assertSame( 'theme', $result['type'] );
+		$this->assertSame( 'twentytwentyfour', $result['slug'] );
+	}
+
+	/**
+	 * Frames inside the plugin itself are skipped when classifying.
+	 */
+	public function test_classify_trace_skips_optrion_frames(): void {
+		$trace  = array(
+			array( 'file' => OPTRION_DIR . 'includes/class-tracker.php' ),
+			array( 'file' => WP_PLUGIN_DIR . '/jetpack/jetpack.php' ),
+		);
+		$result = Tracker::classify_trace( $trace );
+		$this->assertSame( 'plugin', $result['type'] );
+		$this->assertSame( 'jetpack', $result['slug'] );
+	}
+
+	/**
+	 * A trace with no recognized frames is attributed to core.
+	 */
+	public function test_classify_trace_defaults_to_core(): void {
+		$trace  = array(
+			array( 'file' => ABSPATH . 'wp-includes/option.php' ),
+		);
+		$result = Tracker::classify_trace( $trace );
+		$this->assertSame( 'core', $result['type'] );
+	}
+
+	/**
+	 * The tracker should skip when the activation transient is missing.
+	 */
+	public function test_should_track_returns_false_without_transient(): void {
+		delete_transient( Tracker::ENABLE_TRANSIENT );
+		$this->assertFalse( Tracker::should_track_this_request() );
+	}
+
+	/**
+	 * Transient plus sampling=100 enables tracking.
+	 */
+	public function test_should_track_returns_true_when_enabled(): void {
+		set_transient( Tracker::ENABLE_TRANSIENT, 1, 60 );
+		update_option( Tracker::SAMPLING_OPTION, 100 );
+		$this->assertTrue( Tracker::should_track_this_request() );
+	}
+
+	/**
+	 * Sampling rate of 0 disables tracking entirely.
+	 */
+	public function test_sampling_zero_disables_tracking(): void {
+		set_transient( Tracker::ENABLE_TRANSIENT, 1, 60 );
+		update_option( Tracker::SAMPLING_OPTION, 0 );
+		$this->assertFalse( Tracker::should_track_this_request() );
+	}
+
+	/**
+	 * Repeated records for the same option name accumulate in a single row.
+	 */
+	public function test_buffer_dedupes_reads_per_option(): void {
+		$reader = array(
+			'type' => 'plugin',
+			'slug' => 'demo',
+		);
+		Tracker::buffer_record( 'siteurl', $reader, '2026-04-05 00:00:00' );
+		Tracker::buffer_record( 'siteurl', $reader, '2026-04-05 00:00:01' );
+		Tracker::buffer_record( 'home', $reader, '2026-04-05 00:00:02' );
+
+		$snapshot = Tracker::buffer_snapshot();
+		$this->assertCount( 2, $snapshot );
+		$this->assertSame( 2, $snapshot['siteurl']['count'] );
+		$this->assertSame( '2026-04-05 00:00:01', $snapshot['siteurl']['last'] );
+		$this->assertSame( 1, $snapshot['home']['count'] );
+	}
+
+	/**
+	 * Flushing writes buffered reads into the tracking table as an upsert.
+	 */
+	public function test_flush_upserts_into_tracking_table(): void {
+		global $wpdb;
+		$reader = array(
+			'type' => 'plugin',
+			'slug' => 'demo-plugin',
+		);
+		Tracker::buffer_record( 'foo_option', $reader, '2026-04-05 00:00:00' );
+		Tracker::buffer_record( 'foo_option', $reader, '2026-04-05 00:00:01' );
+		Tracker::flush();
+
+		$table = Schema::tracking_table();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE option_name = %s", 'foo_option' ),
+			ARRAY_A
+		);
+		// phpcs:enable
+		$this->assertNotNull( $row );
+		$this->assertSame( '2', (string) $row['read_count'] );
+		$this->assertSame( 'demo-plugin', $row['last_reader'] );
+		$this->assertSame( 'plugin', $row['reader_type'] );
+
+		// A second flush for the same option should accumulate count.
+		Tracker::buffer_record( 'foo_option', $reader, '2026-04-05 00:00:05' );
+		Tracker::flush();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$total = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT read_count FROM {$table} WHERE option_name = %s", 'foo_option' )
+		);
+		// phpcs:enable
+		$this->assertSame( 3, $total );
+	}
+
+	/**
+	 * Recording alloptions buffers every key in the array.
+	 */
+	public function test_record_alloptions_buffers_each_key(): void {
+		$input  = array(
+			'siteurl' => 'https://example.com',
+			'home'    => 'https://example.com',
+		);
+		$result = Tracker::record_alloptions( $input );
+		$this->assertSame( $input, $result );
+		$snapshot = Tracker::buffer_snapshot();
+		$this->assertArrayHasKey( 'siteurl', $snapshot );
+		$this->assertArrayHasKey( 'home', $snapshot );
+	}
+}


### PR DESCRIPTION
## Summary
- Implements the Tracker module per docs/DESIGN.md §4.1
- Captures autoload reads via \`alloptions\` filter; non-autoload via dynamically registered \`option_{\$name}\` filters on admin_init
- Attributes each read to plugin/theme/core by walking the backtrace against WP_PLUGIN_DIR / WPMU_PLUGIN_DIR / get_theme_root(), skipping frames inside Optrion itself
- Buffers in memory and flushes once at shutdown as a batched upsert (INSERT ... ON DUPLICATE KEY UPDATE)
- Gated on \`optrion_tracking_enabled\` transient (refreshed by admin traffic for 10min) + \`optrion_sampling_rate\` option; no-ops during cron and WP-CLI

Closes #10

## Test plan
- [ ] CI PHPUnit green across matrix
- [ ] Manual smoke: visit wp-admin, confirm transient is set, tracking rows appear in \`wp_options_tracking\`