### PR TITLE
feat: 5-axis unused-likelihood scorer with owner inference (#11)

### DIFF
--- a/includes/class-scorer.php
+++ b/includes/class-scorer.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * Option unused-likelihood scorer.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Assigns a 0-100 "probably unused" score to a wp_options row.
+ *
+ * Rules and label bands come from docs/DESIGN.md §4.2.
+ */
+final class Scorer {
+
+	public const LABEL_SAFE          = 'safe';
+	public const LABEL_REVIEW        = 'review';
+	public const LABEL_LIKELY_UNUSED = 'likely_unused';
+	public const LABEL_ALMOST_UNUSED = 'almost_unused';
+	public const OWNER_TYPE_PLUGIN   = 'plugin';
+	public const OWNER_TYPE_THEME    = 'theme';
+	public const OWNER_TYPE_CORE     = 'core';
+	public const OWNER_TYPE_UNKNOWN  = 'unknown';
+
+	/**
+	 * Scores a single option row.
+	 *
+	 * @param array{option_name:string,size_bytes?:int,option_value?:mixed,autoload:string}                                                  $option   Row data from wp_options (plus computed size).
+	 * @param array{last_read_at:?string,read_count:int,last_reader:string,reader_type:string}|null                                          $tracking Tracking row for the option, or null if untracked.
+	 * @param array{active_plugin_slugs:string[],installed_plugin_slugs:string[],active_theme_slugs:string[],installed_theme_slugs:string[]} $context Site context.
+	 * @param DateTimeInterface|null                                                                                                         $now Reference "now" for freshness math. Defaults to current UTC time.
+	 *
+	 * @return array{total:int,label:string,owner:array{type:string,slug:string},breakdown:array<string,int>}
+	 */
+	public static function score( array $option, ?array $tracking, array $context, ?DateTimeInterface $now = null ): array {
+		$now   = $now ?? new DateTimeImmutable( 'now' );
+		$owner = self::infer_owner( $option['option_name'], $tracking, $context );
+
+		$breakdown = array(
+			'owner'          => self::score_owner( $owner, $context ),
+			'freshness'      => self::score_freshness( $tracking, $now ),
+			'transient'      => self::score_transient( $option['option_name'] ),
+			'autoload_waste' => self::score_autoload_waste( $option, $tracking ),
+			'size'           => self::score_size( $option ),
+		);
+
+		$total = min( 100, array_sum( $breakdown ) );
+
+		return array(
+			'total'     => $total,
+			'label'     => self::label_for( $total ),
+			'owner'     => $owner,
+			'breakdown' => $breakdown,
+		);
+	}
+
+	/**
+	 * Maps a numeric score to a labeled band.
+	 *
+	 * @param int $total Score in 0-100.
+	 */
+	public static function label_for( int $total ): string {
+		if ( $total >= 80 ) {
+			return self::LABEL_ALMOST_UNUSED;
+		}
+		if ( $total >= 50 ) {
+			return self::LABEL_LIKELY_UNUSED;
+		}
+		if ( $total >= 20 ) {
+			return self::LABEL_REVIEW;
+		}
+		return self::LABEL_SAFE;
+	}
+
+	/**
+	 * Builds the live site-wide context used as input to score().
+	 *
+	 * Gathers active + installed plugin/theme slugs. Kept separate from the
+	 * pure `score()` method so callers can cache the context for a bulk pass.
+	 *
+	 * @return array{active_plugin_slugs:string[],installed_plugin_slugs:string[],active_theme_slugs:string[],installed_theme_slugs:string[]}
+	 */
+	public static function build_context(): array {
+		$active_plugins = array();
+		foreach ( (array) get_option( 'active_plugins', array() ) as $entry ) {
+			$active_plugins[] = self::plugin_file_to_slug( (string) $entry );
+		}
+
+		$installed_plugins = array();
+		if ( function_exists( 'get_plugins' ) ) {
+			foreach ( array_keys( get_plugins() ) as $entry ) {
+				$installed_plugins[] = self::plugin_file_to_slug( (string) $entry );
+			}
+		}
+
+		$active_theme_slugs    = array();
+		$installed_theme_slugs = array();
+		if ( function_exists( 'wp_get_theme' ) ) {
+			$current = wp_get_theme();
+			if ( $current && $current->exists() ) {
+				$active_theme_slugs[] = $current->get_stylesheet();
+				$parent               = $current->parent();
+				if ( $parent && $parent->exists() ) {
+					$active_theme_slugs[] = $parent->get_stylesheet();
+				}
+			}
+		}
+		if ( function_exists( 'wp_get_themes' ) ) {
+			foreach ( wp_get_themes() as $stylesheet => $_theme ) {
+				$installed_theme_slugs[] = (string) $stylesheet;
+			}
+		}
+
+		return array(
+			'active_plugin_slugs'    => array_values( array_unique( $active_plugins ) ),
+			'installed_plugin_slugs' => array_values( array_unique( $installed_plugins ) ),
+			'active_theme_slugs'     => array_values( array_unique( $active_theme_slugs ) ),
+			'installed_theme_slugs'  => array_values( array_unique( $installed_theme_slugs ) ),
+		);
+	}
+
+	/**
+	 * Infers the owner of an option by consulting tracking data, prefix matches, and the core registry.
+	 *
+	 * @param string                                                                $option_name Raw option name.
+	 * @param array{last_reader:string,reader_type:string}|null                     $tracking    Tracking record or null.
+	 * @param array{installed_plugin_slugs:string[],installed_theme_slugs:string[]} $context     Site context.
+	 *
+	 * @return array{type:string,slug:string}
+	 */
+	public static function infer_owner( string $option_name, ?array $tracking, array $context ): array {
+		if (
+			null !== $tracking
+			&& ! empty( $tracking['last_reader'] )
+			&& self::OWNER_TYPE_UNKNOWN !== ( $tracking['reader_type'] ?? self::OWNER_TYPE_UNKNOWN )
+		) {
+			return array(
+				'type' => (string) $tracking['reader_type'],
+				'slug' => (string) $tracking['last_reader'],
+			);
+		}
+
+		foreach ( ( $context['installed_plugin_slugs'] ?? array() ) as $slug ) {
+			if ( '' !== $slug && self::name_starts_with_slug( $option_name, $slug ) ) {
+				return array(
+					'type' => self::OWNER_TYPE_PLUGIN,
+					'slug' => $slug,
+				);
+			}
+		}
+
+		foreach ( ( $context['installed_theme_slugs'] ?? array() ) as $slug ) {
+			if ( '' !== $slug && self::name_starts_with_slug( $option_name, $slug ) ) {
+				return array(
+					'type' => self::OWNER_TYPE_THEME,
+					'slug' => $slug,
+				);
+			}
+		}
+
+		if ( CoreOptions::contains( $option_name ) ) {
+			return array(
+				'type' => self::OWNER_TYPE_CORE,
+				'slug' => 'wordpress',
+			);
+		}
+
+		return array(
+			'type' => self::OWNER_TYPE_UNKNOWN,
+			'slug' => '',
+		);
+	}
+
+	/**
+	 * Axis 1 — owner state. Max 40 points.
+	 *
+	 * @param array{type:string,slug:string}                                  $owner   Inferred owner.
+	 * @param array{active_plugin_slugs:string[],active_theme_slugs:string[]} $context Site context.
+	 */
+	private static function score_owner( array $owner, array $context ): int {
+		switch ( $owner['type'] ) {
+			case self::OWNER_TYPE_CORE:
+				return 0;
+			case self::OWNER_TYPE_UNKNOWN:
+				return 20;
+			case self::OWNER_TYPE_PLUGIN:
+				return in_array( $owner['slug'], $context['active_plugin_slugs'] ?? array(), true ) ? 0 : 40;
+			case self::OWNER_TYPE_THEME:
+				return in_array( $owner['slug'], $context['active_theme_slugs'] ?? array(), true ) ? 0 : 40;
+			default:
+				return 0;
+		}
+	}
+
+	/**
+	 * Axis 2 — freshness of last recorded read. Max 25 points.
+	 *
+	 * @param array{last_read_at:?string}|null $tracking Tracking record or null.
+	 * @param DateTimeInterface                $now      Reference "now".
+	 */
+	private static function score_freshness( ?array $tracking, DateTimeInterface $now ): int {
+		if ( null === $tracking || empty( $tracking['last_read_at'] ) ) {
+			return 25;
+		}
+		$last = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', (string) $tracking['last_read_at'] );
+		if ( false === $last ) {
+			return 25;
+		}
+		$days = (int) floor( ( $now->getTimestamp() - $last->getTimestamp() ) / 86400 );
+		if ( $days < 90 ) {
+			return 0;
+		}
+		$extra = (int) floor( ( $days - 90 ) / 30 );
+		return (int) min( 25, 5 + $extra * 5 );
+	}
+
+	/**
+	 * Axis 3 — transient prefixes. 10 points if matched.
+	 *
+	 * @param string $option_name Raw option_name.
+	 */
+	private static function score_transient( string $option_name ): int {
+		if ( 0 === strpos( $option_name, '_transient_' ) || 0 === strpos( $option_name, '_site_transient_' ) ) {
+			return 10;
+		}
+		return 0;
+	}
+
+	/**
+	 * Axis 4 — autoload waste. 15 points if autoload=yes but never read during tracking.
+	 *
+	 * @param array{autoload:string}     $option   Option row fragment.
+	 * @param array{read_count:int}|null $tracking Tracking record or null.
+	 */
+	private static function score_autoload_waste( array $option, ?array $tracking ): int {
+		if ( ! self::is_autoloaded( (string) $option['autoload'] ) ) {
+			return 0;
+		}
+		$reads = null === $tracking ? 0 : (int) ( $tracking['read_count'] ?? 0 );
+		return 0 === $reads ? 15 : 0;
+	}
+
+	/**
+	 * Axis 5 — serialized size. 10 / 5 / 0.
+	 *
+	 * @param array{size_bytes?:int,option_value?:mixed} $option Option row fragment.
+	 */
+	private static function score_size( array $option ): int {
+		if ( isset( $option['size_bytes'] ) ) {
+			$bytes = (int) $option['size_bytes'];
+		} elseif ( array_key_exists( 'option_value', $option ) ) {
+			$serialized = is_string( $option['option_value'] ) ? $option['option_value'] : maybe_serialize( $option['option_value'] );
+			$bytes      = strlen( (string) $serialized );
+		} else {
+			$bytes = 0;
+		}
+		if ( $bytes > 100 * 1024 ) {
+			return 10;
+		}
+		if ( $bytes > 10 * 1024 ) {
+			return 5;
+		}
+		return 0;
+	}
+
+	/**
+	 * Checks whether the autoload column value represents "autoloaded".
+	 *
+	 * Handles legacy ('yes'/'no') and WP 6.6+ ('auto'/'on'/'off'/'auto-on'/'auto-off') values.
+	 *
+	 * @param string $autoload Raw autoload column value.
+	 */
+	public static function is_autoloaded( string $autoload ): bool {
+		$autoload = strtolower( $autoload );
+		return in_array( $autoload, array( 'yes', 'on', 'auto', 'auto-on' ), true );
+	}
+
+	/**
+	 * Returns true if $option_name's prefix matches $slug.
+	 *
+	 * Matching is case-insensitive and treats '-' and '_' as interchangeable
+	 * so that slug `my-plugin` matches option name `my_plugin_setting`.
+	 *
+	 * @param string $option_name Option name.
+	 * @param string $slug        Plugin or theme slug.
+	 */
+	private static function name_starts_with_slug( string $option_name, string $slug ): bool {
+		$normalize = static function ( string $value ): string {
+			return str_replace( '-', '_', strtolower( $value ) );
+		};
+		$option_n  = $normalize( $option_name );
+		$slug_n    = $normalize( $slug );
+		if ( '' === $slug_n ) {
+			return false;
+		}
+		if ( 0 !== strpos( $option_n, $slug_n ) ) {
+			return false;
+		}
+		$len = strlen( $slug_n );
+		if ( strlen( $option_n ) === $len ) {
+			return true;
+		}
+		$boundary = $option_n[ $len ];
+		return '_' === $boundary;
+	}
+
+	/**
+	 * Derives a plugin slug from `folder/main.php` or `single-file.php`.
+	 *
+	 * @param string $plugin_file Active plugins entry.
+	 */
+	private static function plugin_file_to_slug( string $plugin_file ): string {
+		$slash = strpos( $plugin_file, '/' );
+		if ( false === $slash ) {
+			return preg_replace( '/\.php$/', '', $plugin_file ) ?? $plugin_file;
+		}
+		return substr( $plugin_file, 0, $slash );
+	}
+}

--- a/optrion.php
+++ b/optrion.php
@@ -32,6 +32,7 @@ if ( is_readable( $optrion_autoload ) ) {
 require_once OPTRION_DIR . 'includes/class-schema.php';
 require_once OPTRION_DIR . 'includes/class-core-options.php';
 require_once OPTRION_DIR . 'includes/class-tracker.php';
+require_once OPTRION_DIR . 'includes/class-scorer.php';
 require_once OPTRION_DIR . 'includes/class-plugin.php';
 
 register_activation_hook( __FILE__, array( \Optrion\Plugin::class, 'activate' ) );

--- a/tests/test-scorer.php
+++ b/tests/test-scorer.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * Scorer tests.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion\Tests;
+
+use DateTimeImmutable;
+use Optrion\Scorer;
+use WP_UnitTestCase;
+
+/**
+ * Covers the five scoring axes, owner inference, and label banding.
+ *
+ * @coversDefaultClass \Optrion\Scorer
+ */
+class ScorerTest extends WP_UnitTestCase {
+
+	/**
+	 * Fixed "now" used by every test for deterministic freshness math.
+	 *
+	 * @var DateTimeImmutable
+	 */
+	private DateTimeImmutable $now;
+
+	/**
+	 * Minimal synthetic site context.
+	 *
+	 * @var array{active_plugin_slugs:string[],installed_plugin_slugs:string[],active_theme_slugs:string[],installed_theme_slugs:string[]}
+	 */
+	private array $context;
+
+	/**
+	 * Sets a fixed clock and a small set of known plugins/themes.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->now     = new DateTimeImmutable( '2026-06-01 12:00:00' );
+		$this->context = array(
+			'active_plugin_slugs'    => array( 'woocommerce' ),
+			'installed_plugin_slugs' => array( 'woocommerce', 'old-plugin' ),
+			'active_theme_slugs'     => array( 'twentytwentyfour' ),
+			'installed_theme_slugs'  => array( 'twentytwentyfour', 'oldtheme' ),
+		);
+	}
+
+	/**
+	 * Label banding matches the design doc thresholds.
+	 */
+	public function test_label_for_bands(): void {
+		$this->assertSame( Scorer::LABEL_SAFE, Scorer::label_for( 0 ) );
+		$this->assertSame( Scorer::LABEL_SAFE, Scorer::label_for( 19 ) );
+		$this->assertSame( Scorer::LABEL_REVIEW, Scorer::label_for( 20 ) );
+		$this->assertSame( Scorer::LABEL_REVIEW, Scorer::label_for( 49 ) );
+		$this->assertSame( Scorer::LABEL_LIKELY_UNUSED, Scorer::label_for( 50 ) );
+		$this->assertSame( Scorer::LABEL_LIKELY_UNUSED, Scorer::label_for( 79 ) );
+		$this->assertSame( Scorer::LABEL_ALMOST_UNUSED, Scorer::label_for( 80 ) );
+		$this->assertSame( Scorer::LABEL_ALMOST_UNUSED, Scorer::label_for( 100 ) );
+	}
+
+	/**
+	 * A core option with recent reads and small size scores zero.
+	 */
+	public function test_core_option_scores_zero(): void {
+		$option   = array(
+			'option_name' => 'siteurl',
+			'size_bytes'  => 20,
+			'autoload'    => 'yes',
+		);
+		$tracking = array(
+			'last_read_at' => '2026-06-01 10:00:00',
+			'read_count'   => 10,
+			'last_reader'  => 'wordpress',
+			'reader_type'  => 'core',
+		);
+		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
+		$this->assertSame( 0, $result['total'] );
+		$this->assertSame( Scorer::OWNER_TYPE_CORE, $result['owner']['type'] );
+		$this->assertSame( Scorer::LABEL_SAFE, $result['label'] );
+	}
+
+	/**
+	 * An option whose plugin owner is inactive accrues the 40-point owner penalty.
+	 */
+	public function test_inactive_plugin_owner_scores_40_on_owner_axis(): void {
+		$option   = array(
+			'option_name' => 'old_plugin_settings',
+			'size_bytes'  => 100,
+			'autoload'    => 'no',
+		);
+		$tracking = null; // Never tracked.
+		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
+		$this->assertSame( 40, $result['breakdown']['owner'] );
+		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
+		$this->assertSame( 'old-plugin', $result['owner']['slug'] );
+	}
+
+	/**
+	 * Freshness scoring: no record = 25.
+	 */
+	public function test_freshness_missing_record_is_25(): void {
+		$option = array(
+			'option_name' => 'foo_bar',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+		$result = Scorer::score( $option, null, $this->context, $this->now );
+		$this->assertSame( 25, $result['breakdown']['freshness'] );
+	}
+
+	/**
+	 * Freshness scoring: <90 days is 0.
+	 */
+	public function test_freshness_recent_is_zero(): void {
+		$option   = array(
+			'option_name' => 'foo_bar',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+		$tracking = array(
+			'last_read_at' => '2026-04-01 00:00:00', // ~60 days before 2026-06-01
+			'read_count'   => 1,
+			'last_reader'  => '',
+			'reader_type'  => 'unknown',
+		);
+		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
+		$this->assertSame( 0, $result['breakdown']['freshness'] );
+	}
+
+	/**
+	 * Freshness scoring scales at 5 pts per extra 30 days after 90, capped at 25.
+	 */
+	public function test_freshness_scales_with_age(): void {
+		$option = array(
+			'option_name' => 'foo_bar',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+
+		// Exactly 90 days old → 5 points.
+		$tracking_90 = array(
+			'last_read_at' => '2026-03-03 12:00:00',
+			'read_count'   => 1,
+			'last_reader'  => '',
+			'reader_type'  => 'unknown',
+		);
+		$this->assertSame( 5, Scorer::score( $option, $tracking_90, $this->context, $this->now )['breakdown']['freshness'] );
+
+		// 120 days old → 10.
+		$tracking_120 = array(
+			'last_read_at' => '2026-02-01 12:00:00',
+			'read_count'   => 1,
+			'last_reader'  => '',
+			'reader_type'  => 'unknown',
+		);
+		$this->assertSame( 10, Scorer::score( $option, $tracking_120, $this->context, $this->now )['breakdown']['freshness'] );
+
+		// 2 years old → capped at 25.
+		$tracking_old = array(
+			'last_read_at' => '2024-01-01 00:00:00',
+			'read_count'   => 1,
+			'last_reader'  => '',
+			'reader_type'  => 'unknown',
+		);
+		$this->assertSame( 25, Scorer::score( $option, $tracking_old, $this->context, $this->now )['breakdown']['freshness'] );
+	}
+
+	/**
+	 * Transient prefix adds 10 points.
+	 */
+	public function test_transient_prefix_adds_10(): void {
+		$option = array(
+			'option_name' => '_transient_some_cache',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+		$result = Scorer::score( $option, null, $this->context, $this->now );
+		$this->assertSame( 10, $result['breakdown']['transient'] );
+
+		$option['option_name'] = '_site_transient_x';
+		$result                = Scorer::score( $option, null, $this->context, $this->now );
+		$this->assertSame( 10, $result['breakdown']['transient'] );
+	}
+
+	/**
+	 * Autoload + zero reads = 15 point waste penalty.
+	 */
+	public function test_autoload_waste_fires_only_when_autoloaded_and_unread(): void {
+		$option          = array(
+			'option_name' => 'something',
+			'size_bytes'  => 10,
+			'autoload'    => 'yes',
+		);
+		$tracking_unread = array(
+			'last_read_at' => null,
+			'read_count'   => 0,
+			'last_reader'  => '',
+			'reader_type'  => 'unknown',
+		);
+		$result          = Scorer::score( $option, $tracking_unread, $this->context, $this->now );
+		$this->assertSame( 15, $result['breakdown']['autoload_waste'] );
+
+		$tracking_read = array(
+			'last_read_at' => '2026-05-01 00:00:00',
+			'read_count'   => 3,
+			'last_reader'  => '',
+			'reader_type'  => 'unknown',
+		);
+		$result        = Scorer::score( $option, $tracking_read, $this->context, $this->now );
+		$this->assertSame( 0, $result['breakdown']['autoload_waste'] );
+
+		$option['autoload'] = 'no';
+		$result             = Scorer::score( $option, $tracking_unread, $this->context, $this->now );
+		$this->assertSame( 0, $result['breakdown']['autoload_waste'] );
+	}
+
+	/**
+	 * Size axis: >100KB=10, >10KB=5, else 0.
+	 */
+	public function test_size_axis_thresholds(): void {
+		$base = array(
+			'option_name' => 'x',
+			'autoload'    => 'no',
+		);
+		$this->assertSame( 0, Scorer::score( array_merge( $base, array( 'size_bytes' => 5000 ) ), null, $this->context, $this->now )['breakdown']['size'] );
+		$this->assertSame( 5, Scorer::score( array_merge( $base, array( 'size_bytes' => 20 * 1024 ) ), null, $this->context, $this->now )['breakdown']['size'] );
+		$this->assertSame( 10, Scorer::score( array_merge( $base, array( 'size_bytes' => 200 * 1024 ) ), null, $this->context, $this->now )['breakdown']['size'] );
+	}
+
+	/**
+	 * Totals are clipped at 100.
+	 */
+	public function test_total_is_capped_at_100(): void {
+		$option = array(
+			'option_name' => '_transient_old_plugin_huge_blob',
+			'size_bytes'  => 500 * 1024,
+			'autoload'    => 'yes',
+		);
+		// Owner=plugin inactive (40) + freshness=25 (no record) + transient=10 + autoload_waste=15 + size=10 = 100.
+		$result = Scorer::score( $option, null, $this->context, $this->now );
+		$this->assertLessThanOrEqual( 100, $result['total'] );
+		$this->assertSame( 100, $result['total'] );
+	}
+
+	/**
+	 * Owner inference prioritizes tracker data over prefix matching.
+	 */
+	public function test_owner_inference_prefers_tracker(): void {
+		$option   = array(
+			'option_name' => 'woocommerce_settings',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+		$tracking = array(
+			'last_read_at' => '2026-05-01 00:00:00',
+			'read_count'   => 3,
+			'last_reader'  => 'custom-mu',
+			'reader_type'  => 'plugin',
+		);
+		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
+		$this->assertSame( 'custom-mu', $result['owner']['slug'] );
+	}
+
+	/**
+	 * Owner inference falls back to prefix matching when tracker is unknown.
+	 */
+	public function test_owner_inference_uses_prefix_match(): void {
+		$option = array(
+			'option_name' => 'woocommerce_settings',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+		$result = Scorer::score( $option, null, $this->context, $this->now );
+		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
+		$this->assertSame( 'woocommerce', $result['owner']['slug'] );
+	}
+
+	/**
+	 * Unknown owner gets 20 on the owner axis.
+	 */
+	public function test_owner_inference_defaults_to_unknown(): void {
+		$option = array(
+			'option_name' => 'random_mystery_thing',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+		$result = Scorer::score( $option, null, $this->context, $this->now );
+		$this->assertSame( Scorer::OWNER_TYPE_UNKNOWN, $result['owner']['type'] );
+		$this->assertSame( 20, $result['breakdown']['owner'] );
+	}
+
+	/**
+	 * Prefix matching treats dash/underscore interchangeably.
+	 */
+	public function test_prefix_match_handles_dash_underscore(): void {
+		$context                           = $this->context;
+		$context['installed_plugin_slugs'] = array_merge( $context['installed_plugin_slugs'], array( 'my-cool-plugin' ) );
+		$option                            = array(
+			'option_name' => 'my_cool_plugin_settings',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+		$result                            = Scorer::score( $option, null, $context, $this->now );
+		$this->assertSame( 'my-cool-plugin', $result['owner']['slug'] );
+	}
+
+	/**
+	 * Context gathered from a live WP install returns the expected shape.
+	 */
+	public function test_build_context_returns_expected_shape(): void {
+		$ctx = Scorer::build_context();
+		$this->assertArrayHasKey( 'active_plugin_slugs', $ctx );
+		$this->assertArrayHasKey( 'installed_plugin_slugs', $ctx );
+		$this->assertArrayHasKey( 'active_theme_slugs', $ctx );
+		$this->assertArrayHasKey( 'installed_theme_slugs', $ctx );
+		$this->assertIsArray( $ctx['active_plugin_slugs'] );
+	}
+}

--- a/tests/test-scorer.php
+++ b/tests/test-scorer.php
@@ -232,16 +232,23 @@ class ScorerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Totals are clipped at 100.
+	 * Totals accumulate to the design maximum of 100.
 	 */
-	public function test_total_is_capped_at_100(): void {
+	public function test_total_accumulates_to_100(): void {
 		$option = array(
 			'option_name' => '_transient_old_plugin_huge_blob',
 			'size_bytes'  => 500 * 1024,
 			'autoload'    => 'yes',
 		);
-		// Owner=plugin inactive (40) + freshness=25 (no record) + transient=10 + autoload_waste=15 + size=10 = 100.
-		$result = Scorer::score( $option, null, $this->context, $this->now );
+		// Use tracker-sourced owner so the transient prefix does not block attribution.
+		$tracking = array(
+			'last_read_at' => null,
+			'read_count'   => 0,
+			'last_reader'  => 'old-plugin',
+			'reader_type'  => 'plugin',
+		);
+		// Owner(inactive plugin)=40 + freshness(no record)=25 + transient=10 + autoload_waste=15 + size(>100KB)=10 = 100.
+		$result = Scorer::score( $option, $tracking, $this->context, $this->now );
 		$this->assertLessThanOrEqual( 100, $result['total'] );
 		$this->assertSame( 100, $result['total'] );
 	}


### PR DESCRIPTION
## Summary
Implements the Scorer module per docs/DESIGN.md §4.2.

**Scoring axes (total capped at 100):**
- Owner state (40): inactive plugin/theme=40, unknown=20, core/active=0
- Freshness (25): 5pts at 90d, +5 per 30d, 25 if untracked
- Transient prefix (10)
- Autoload waste (15): autoload=yes + read_count=0
- Size (10/5/0)

**Owner inference:** tracker → plugin-prefix → theme-prefix → core registry → unknown (dash/underscore interchangeable)

**API:** \`Scorer::score(\$option, \$tracking, \$context, \$now)\` pure + \`Scorer::build_context()\` collecting live site context for bulk scoring.

Closes #11

## Test plan
- [ ] CI PHPUnit green
- [ ] Spot-check scores on a dev site with a mix of active/inactive plugin options