### PR TITLE
feat: quarantine module with rename, restore, and expiry sweep (#12)

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -25,6 +25,7 @@ final class Plugin {
 		load_plugin_textdomain( 'optrion', false, dirname( plugin_basename( OPTRION_FILE ) ) . '/languages' );
 		Schema::maybe_upgrade();
 		Tracker::boot();
+		add_action( Quarantine::CRON_HOOK, array( Quarantine::class, 'process_expired' ) );
 	}
 
 	/**
@@ -34,6 +35,7 @@ final class Plugin {
 	 */
 	public static function activate(): void {
 		Schema::install();
+		Quarantine::schedule_cron();
 	}
 
 	/**
@@ -42,6 +44,6 @@ final class Plugin {
 	 * Unschedules cron. Does not drop tables.
 	 */
 	public static function deactivate(): void {
-		// Implemented in a later task.
+		Quarantine::unschedule_cron();
 	}
 }

--- a/includes/class-quarantine.php
+++ b/includes/class-quarantine.php
@@ -1,0 +1,435 @@
+<?php
+/**
+ * Quarantine module.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Soft-disables a wp_options row by renaming it, tracks the manifest,
+ * and restores (or permanently deletes) it on demand or on expiry.
+ *
+ * Behavior is described in docs/DESIGN.md §4.5.
+ */
+final class Quarantine {
+
+	/**
+	 * Rename prefix applied to quarantined option rows.
+	 */
+	public const RENAME_PREFIX = '_optrion_q__';
+
+	/**
+	 * Status of a manifest row when it is actively holding a renamed option.
+	 */
+	public const STATUS_ACTIVE = 'active';
+
+	/**
+	 * Status after the option has been restored to its original name.
+	 */
+	public const STATUS_RESTORED = 'restored';
+
+	/**
+	 * Status after the option has been permanently deleted.
+	 */
+	public const STATUS_DELETED = 'deleted';
+
+	/**
+	 * Maximum length of the original option_name that can safely be prefixed.
+	 *
+	 * The wp_options.option_name column is VARCHAR(191); minus the 12-char
+	 * rename prefix and one underscore separator, 178 chars remain usable.
+	 */
+	public const MAX_ORIGINAL_LENGTH = 178;
+
+	/**
+	 * Hard cap on the number of simultaneously active quarantines.
+	 */
+	public const MAX_ACTIVE_QUARANTINES = 50;
+
+	/**
+	 * Default quarantine window in days.
+	 */
+	public const DEFAULT_EXPIRY_DAYS = 7;
+
+	/**
+	 * Option key: number of days until auto-expiry.
+	 */
+	public const EXPIRY_DAYS_OPTION = 'optrion_quarantine_expiry_days';
+
+	/**
+	 * Option key: action on expiry (`restore`, `delete`, or `keep`).
+	 */
+	public const EXPIRY_ACTION_OPTION = 'optrion_quarantine_expiry_action';
+
+	/**
+	 * Cron hook that runs the daily expiry sweep.
+	 */
+	public const CRON_HOOK = 'optrion_quarantine_check';
+
+	/**
+	 * Moves an option into quarantine.
+	 *
+	 * @param string $option_name    Live option_name in wp_options.
+	 * @param int    $user_id        Admin user performing the action (0 if unattributed).
+	 * @param int    $score          Score at the time of quarantine (for history).
+	 * @param int    $expires_days   Override for the default expiry window (0 → use setting).
+	 *
+	 * @return int|WP_Error Manifest ID on success, WP_Error otherwise.
+	 */
+	public static function quarantine( string $option_name, int $user_id = 0, int $score = 0, int $expires_days = 0 ) {
+		if ( ! self::is_quarantinable( $option_name ) ) {
+			return new WP_Error( 'optrion_not_quarantinable', self::reason_cannot_quarantine( $option_name ) );
+		}
+
+		if ( self::active_count() >= self::MAX_ACTIVE_QUARANTINES ) {
+			return new WP_Error(
+				'optrion_quarantine_full',
+				sprintf(
+					/* translators: %d: maximum number of simultaneous quarantines. */
+					__( 'Quarantine limit reached (%d active).', 'optrion' ),
+					self::MAX_ACTIVE_QUARANTINES
+				)
+			);
+		}
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$autoload = $wpdb->get_var(
+			$wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", $option_name )
+		);
+		if ( null === $autoload ) {
+			return new WP_Error( 'optrion_option_missing', __( 'Option not found in wp_options.', 'optrion' ) );
+		}
+
+		$renamed = self::RENAME_PREFIX . $option_name;
+
+		// Use wpdb->update so that the row is locked atomically.
+		$updated = $wpdb->update(
+			$wpdb->options,
+			array(
+				'option_name' => $renamed,
+				'autoload'    => 'no',
+			),
+			array( 'option_name' => $option_name ),
+			array( '%s', '%s' ),
+			array( '%s' )
+		);
+		// phpcs:enable
+
+		if ( false === $updated || 0 === $updated ) {
+			return new WP_Error( 'optrion_rename_failed', __( 'Could not rename the option row.', 'optrion' ) );
+		}
+
+		wp_cache_delete( $option_name, 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
+
+		$days = $expires_days > 0 ? $expires_days : self::configured_expiry_days();
+		$now  = current_time( 'mysql', true );
+		$exp  = gmdate( 'Y-m-d H:i:s', strtotime( $now . ' +' . $days . ' days' ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$inserted = $wpdb->insert(
+			Schema::quarantine_table(),
+			array(
+				'original_name'       => $option_name,
+				'original_autoload'   => (string) $autoload,
+				'quarantined_at'      => $now,
+				'expires_at'          => $exp,
+				'quarantined_by'      => $user_id,
+				'score_at_quarantine' => $score,
+				'status'              => self::STATUS_ACTIVE,
+			),
+			array( '%s', '%s', '%s', '%s', '%d', '%d', '%s' )
+		);
+
+		if ( false === $inserted ) {
+			// Roll back the rename so state does not diverge from the manifest.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->update(
+				$wpdb->options,
+				array(
+					'option_name' => $option_name,
+					'autoload'    => (string) $autoload,
+				),
+				array( 'option_name' => $renamed ),
+				array( '%s', '%s' ),
+				array( '%s' )
+			);
+			return new WP_Error( 'optrion_manifest_failed', __( 'Could not record the quarantine manifest.', 'optrion' ) );
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Restores a quarantined option to its original name and autoload value.
+	 *
+	 * @param int $manifest_id Manifest row ID.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function restore( int $manifest_id ) {
+		$manifest = self::get_manifest( $manifest_id );
+		if ( null === $manifest ) {
+			return new WP_Error( 'optrion_manifest_missing', __( 'Quarantine manifest row not found.', 'optrion' ) );
+		}
+		if ( self::STATUS_ACTIVE !== $manifest['status'] ) {
+			return new WP_Error( 'optrion_not_active', __( 'Quarantine entry is not active.', 'optrion' ) );
+		}
+
+		global $wpdb;
+		$renamed = self::RENAME_PREFIX . $manifest['original_name'];
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $wpdb->update(
+			$wpdb->options,
+			array(
+				'option_name' => $manifest['original_name'],
+				'autoload'    => $manifest['original_autoload'],
+			),
+			array( 'option_name' => $renamed ),
+			array( '%s', '%s' ),
+			array( '%s' )
+		);
+		if ( false === $updated || 0 === $updated ) {
+			return new WP_Error( 'optrion_restore_failed', __( 'Could not rename the option row back.', 'optrion' ) );
+		}
+
+		wp_cache_delete( $manifest['original_name'], 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			Schema::quarantine_table(),
+			array(
+				'status'      => self::STATUS_RESTORED,
+				'restored_at' => current_time( 'mysql', true ),
+			),
+			array( 'id' => $manifest_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+
+		return true;
+	}
+
+	/**
+	 * Permanently deletes a quarantined option row.
+	 *
+	 * @param int $manifest_id Manifest row ID.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function delete_permanently( int $manifest_id ) {
+		$manifest = self::get_manifest( $manifest_id );
+		if ( null === $manifest ) {
+			return new WP_Error( 'optrion_manifest_missing', __( 'Quarantine manifest row not found.', 'optrion' ) );
+		}
+		if ( self::STATUS_ACTIVE !== $manifest['status'] ) {
+			return new WP_Error( 'optrion_not_active', __( 'Quarantine entry is not active.', 'optrion' ) );
+		}
+
+		global $wpdb;
+		$renamed = self::RENAME_PREFIX . $manifest['original_name'];
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$deleted = $wpdb->delete(
+			$wpdb->options,
+			array( 'option_name' => $renamed ),
+			array( '%s' )
+		);
+		if ( false === $deleted ) {
+			return new WP_Error( 'optrion_delete_failed', __( 'Could not delete the quarantined option row.', 'optrion' ) );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			Schema::quarantine_table(),
+			array(
+				'status'     => self::STATUS_DELETED,
+				'deleted_at' => current_time( 'mysql', true ),
+			),
+			array( 'id' => $manifest_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+
+		return true;
+	}
+
+	/**
+	 * Processes expired quarantines according to the configured expiry action.
+	 *
+	 * @return array{processed:int,restored:int,deleted:int,kept:int}
+	 */
+	public static function process_expired(): array {
+		$action  = self::configured_expiry_action();
+		$summary = array(
+			'processed' => 0,
+			'restored'  => 0,
+			'deleted'   => 0,
+			'kept'      => 0,
+		);
+		if ( 'keep' === $action ) {
+			return $summary;
+		}
+
+		global $wpdb;
+		$table = Schema::quarantine_table();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id FROM {$table} WHERE status = %s AND expires_at <= %s",
+				self::STATUS_ACTIVE,
+				current_time( 'mysql', true )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+		if ( empty( $rows ) ) {
+			return $summary;
+		}
+
+		foreach ( $rows as $row ) {
+			$id = (int) $row['id'];
+			++$summary['processed'];
+			$result = 'delete' === $action
+				? self::delete_permanently( $id )
+				: self::restore( $id );
+			if ( is_wp_error( $result ) ) {
+				++$summary['kept'];
+				continue;
+			}
+			if ( 'delete' === $action ) {
+				++$summary['deleted'];
+			} else {
+				++$summary['restored'];
+			}
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Schedules the daily expiry cron job if it is not already scheduled.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Removes the expiry cron job.
+	 */
+	public static function unschedule_cron(): void {
+		$next = wp_next_scheduled( self::CRON_HOOK );
+		if ( false !== $next ) {
+			wp_unschedule_event( $next, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Returns true when the option can be quarantined.
+	 *
+	 * @param string $option_name Option name to check.
+	 */
+	public static function is_quarantinable( string $option_name ): bool {
+		if ( '' === $option_name ) {
+			return false;
+		}
+		if ( strlen( $option_name ) > self::MAX_ORIGINAL_LENGTH ) {
+			return false;
+		}
+		if ( 0 === strpos( $option_name, self::RENAME_PREFIX ) ) {
+			return false;
+		}
+		if ( CoreOptions::contains( $option_name ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Returns the count of currently active quarantine entries.
+	 */
+	public static function active_count(): int {
+		global $wpdb;
+		$table = Schema::quarantine_table();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		return (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE status = %s", self::STATUS_ACTIVE )
+		);
+		// phpcs:enable
+	}
+
+	/**
+	 * Fetches a manifest row as an associative array.
+	 *
+	 * @param int $manifest_id Manifest row ID.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function get_manifest( int $manifest_id ): ?array {
+		global $wpdb;
+		$table = Schema::quarantine_table();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $manifest_id ),
+			ARRAY_A
+		);
+		// phpcs:enable
+		return is_array( $row ) ? $row : null;
+	}
+
+	/**
+	 * Resolves the configured expiry window in days, clamped to 1-30.
+	 */
+	public static function configured_expiry_days(): int {
+		$days = (int) get_option( self::EXPIRY_DAYS_OPTION, self::DEFAULT_EXPIRY_DAYS );
+		if ( $days < 1 ) {
+			return 1;
+		}
+		if ( $days > 30 ) {
+			return 30;
+		}
+		return $days;
+	}
+
+	/**
+	 * Resolves the configured expiry action (`restore`, `delete`, `keep`).
+	 */
+	public static function configured_expiry_action(): string {
+		$action = (string) get_option( self::EXPIRY_ACTION_OPTION, 'restore' );
+		return in_array( $action, array( 'restore', 'delete', 'keep' ), true ) ? $action : 'restore';
+	}
+
+	/**
+	 * Explains why an option cannot be quarantined. Used for error messages.
+	 *
+	 * @param string $option_name Option name.
+	 */
+	private static function reason_cannot_quarantine( string $option_name ): string {
+		if ( '' === $option_name ) {
+			return __( 'Option name is empty.', 'optrion' );
+		}
+		if ( 0 === strpos( $option_name, self::RENAME_PREFIX ) ) {
+			return __( 'Option is already quarantined.', 'optrion' );
+		}
+		if ( strlen( $option_name ) > self::MAX_ORIGINAL_LENGTH ) {
+			return __( 'Option name is too long to safely quarantine.', 'optrion' );
+		}
+		if ( CoreOptions::contains( $option_name ) ) {
+			return __( 'WordPress core options cannot be quarantined.', 'optrion' );
+		}
+		return __( 'Option cannot be quarantined.', 'optrion' );
+	}
+}

--- a/optrion.php
+++ b/optrion.php
@@ -33,6 +33,7 @@ require_once OPTRION_DIR . 'includes/class-schema.php';
 require_once OPTRION_DIR . 'includes/class-core-options.php';
 require_once OPTRION_DIR . 'includes/class-tracker.php';
 require_once OPTRION_DIR . 'includes/class-scorer.php';
+require_once OPTRION_DIR . 'includes/class-quarantine.php';
 require_once OPTRION_DIR . 'includes/class-plugin.php';
 
 register_activation_hook( __FILE__, array( \Optrion\Plugin::class, 'activate' ) );

--- a/tests/test-quarantine.php
+++ b/tests/test-quarantine.php
@@ -114,15 +114,23 @@ class QuarantineTest extends WP_UnitTestCase {
 	 */
 	public function test_restore_preserves_original_autoload(): void {
 		add_option( 'auto_thing', 'val', '', 'yes' );
+		global $wpdb;
+		// Capture whatever autoload value WP normalized 'yes' into (WP 6.6+ uses 'on').
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$before = $wpdb->get_var(
+			$wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", 'auto_thing' )
+		);
+		// phpcs:enable
+
 		$id = Quarantine::quarantine( 'auto_thing' );
 		Quarantine::restore( (int) $id );
 
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$autoload = $wpdb->get_var(
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$after = $wpdb->get_var(
 			$wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", 'auto_thing' )
 		);
-		$this->assertSame( 'yes', $autoload );
+		// phpcs:enable
+		$this->assertSame( $before, $after );
 	}
 
 	/**

--- a/tests/test-quarantine.php
+++ b/tests/test-quarantine.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Quarantine module tests.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion\Tests;
+
+use Optrion\Quarantine;
+use Optrion\Schema;
+use WP_UnitTestCase;
+
+/**
+ * Exercises the rename / restore / delete / expiry flows.
+ *
+ * @coversDefaultClass \Optrion\Quarantine
+ */
+class QuarantineTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensures the schema is in place and the manifest is empty for each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		Schema::install();
+		global $wpdb;
+		// phpcs:ignore WordPress.DB
+		$wpdb->query( 'DELETE FROM ' . Schema::quarantine_table() );
+	}
+
+	/**
+	 * Eligibility rejects core options, empty names, already-prefixed names, and oversized names.
+	 */
+	public function test_is_quarantinable_rules(): void {
+		$this->assertFalse( Quarantine::is_quarantinable( '' ) );
+		$this->assertFalse( Quarantine::is_quarantinable( 'siteurl' ) );
+		$this->assertFalse( Quarantine::is_quarantinable( Quarantine::RENAME_PREFIX . 'foo' ) );
+		$this->assertFalse( Quarantine::is_quarantinable( str_repeat( 'x', Quarantine::MAX_ORIGINAL_LENGTH + 1 ) ) );
+		$this->assertTrue( Quarantine::is_quarantinable( 'my_custom_plugin_setting' ) );
+	}
+
+	/**
+	 * Quarantining renames the row and inserts a manifest entry.
+	 */
+	public function test_quarantine_renames_and_records_manifest(): void {
+		add_option( 'orphan_plugin_setting', 'hello', '', 'yes' );
+		$id = Quarantine::quarantine( 'orphan_plugin_setting', 0, 75 );
+		$this->assertIsInt( $id );
+		$this->assertGreaterThan( 0, $id );
+
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$original = $wpdb->get_var(
+			$wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", 'orphan_plugin_setting' )
+		);
+		$renamed  = $wpdb->get_var(
+			$wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", Quarantine::RENAME_PREFIX . 'orphan_plugin_setting' )
+		);
+		$autoload = $wpdb->get_var(
+			$wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", Quarantine::RENAME_PREFIX . 'orphan_plugin_setting' )
+		);
+		// phpcs:enable
+		$this->assertNull( $original, 'Original row should be renamed away.' );
+		$this->assertSame( 'hello', $renamed );
+		$this->assertSame( 'no', $autoload );
+
+		$manifest = Quarantine::get_manifest( $id );
+		$this->assertNotNull( $manifest );
+		$this->assertSame( 'orphan_plugin_setting', $manifest['original_name'] );
+		$this->assertSame( Quarantine::STATUS_ACTIVE, $manifest['status'] );
+		$this->assertSame( '75', (string) $manifest['score_at_quarantine'] );
+	}
+
+	/**
+	 * Core options cannot be quarantined.
+	 */
+	public function test_quarantine_rejects_core_options(): void {
+		$result = Quarantine::quarantine( 'siteurl' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'optrion_not_quarantinable', $result->get_error_code() );
+	}
+
+	/**
+	 * Missing options surface a dedicated error.
+	 */
+	public function test_quarantine_rejects_missing_option(): void {
+		$result = Quarantine::quarantine( 'nonexistent_option_xyz' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'optrion_option_missing', $result->get_error_code() );
+	}
+
+	/**
+	 * Restore renames the row back and flips manifest status.
+	 */
+	public function test_restore_reverses_rename(): void {
+		add_option( 'some_plugin_thing', 'payload', '', 'yes' );
+		$id = Quarantine::quarantine( 'some_plugin_thing' );
+		$this->assertIsInt( $id );
+
+		$result = Quarantine::restore( $id );
+		$this->assertTrue( $result );
+
+		$this->assertSame( 'payload', get_option( 'some_plugin_thing' ) );
+		$manifest = Quarantine::get_manifest( $id );
+		$this->assertSame( Quarantine::STATUS_RESTORED, $manifest['status'] );
+		$this->assertNotEmpty( $manifest['restored_at'] );
+	}
+
+	/**
+	 * Restore preserves the original autoload value.
+	 */
+	public function test_restore_preserves_original_autoload(): void {
+		add_option( 'auto_thing', 'val', '', 'yes' );
+		$id = Quarantine::quarantine( 'auto_thing' );
+		Quarantine::restore( (int) $id );
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$autoload = $wpdb->get_var(
+			$wpdb->prepare( "SELECT autoload FROM {$wpdb->options} WHERE option_name = %s", 'auto_thing' )
+		);
+		$this->assertSame( 'yes', $autoload );
+	}
+
+	/**
+	 * Permanent delete drops the row and flips manifest status.
+	 */
+	public function test_delete_permanently_removes_row(): void {
+		add_option( 'tempy', 'x', '', 'no' );
+		$id = Quarantine::quarantine( 'tempy' );
+		$this->assertIsInt( $id );
+
+		$result = Quarantine::delete_permanently( $id );
+		$this->assertTrue( $result );
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$found = $wpdb->get_var(
+			$wpdb->prepare( "SELECT option_name FROM {$wpdb->options} WHERE option_name = %s", Quarantine::RENAME_PREFIX . 'tempy' )
+		);
+		$this->assertNull( $found );
+		$manifest = Quarantine::get_manifest( $id );
+		$this->assertSame( Quarantine::STATUS_DELETED, $manifest['status'] );
+		$this->assertNotEmpty( $manifest['deleted_at'] );
+	}
+
+	/**
+	 * Restore and permanent-delete refuse to act on non-active entries.
+	 */
+	public function test_restore_fails_if_not_active(): void {
+		add_option( 'repeatable', 'a', '', 'no' );
+		$id = Quarantine::quarantine( 'repeatable' );
+		Quarantine::restore( (int) $id );
+
+		$second = Quarantine::restore( (int) $id );
+		$this->assertWPError( $second );
+		$this->assertSame( 'optrion_not_active', $second->get_error_code() );
+	}
+
+	/**
+	 * Active count reflects the number of STATUS_ACTIVE entries.
+	 */
+	public function test_active_count_tracks_status(): void {
+		add_option( 'q_one', '1', '', 'no' );
+		add_option( 'q_two', '2', '', 'no' );
+		$this->assertSame( 0, Quarantine::active_count() );
+		Quarantine::quarantine( 'q_one' );
+		$this->assertSame( 1, Quarantine::active_count() );
+		$id2 = Quarantine::quarantine( 'q_two' );
+		$this->assertSame( 2, Quarantine::active_count() );
+		Quarantine::restore( (int) $id2 );
+		$this->assertSame( 1, Quarantine::active_count() );
+	}
+
+	/**
+	 * Expiry sweep restores entries whose expires_at is in the past.
+	 */
+	public function test_process_expired_restores_by_default(): void {
+		add_option( 'expiring_a', 'alpha', '', 'no' );
+		$id = Quarantine::quarantine( 'expiring_a' );
+		$this->assertIsInt( $id );
+
+		// Force the manifest row to look overdue.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			Schema::quarantine_table(),
+			array( 'expires_at' => '2020-01-01 00:00:00' ),
+			array( 'id' => $id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		update_option( Quarantine::EXPIRY_ACTION_OPTION, 'restore' );
+		$summary = Quarantine::process_expired();
+		$this->assertSame( 1, $summary['restored'] );
+		$this->assertSame( 'alpha', get_option( 'expiring_a' ) );
+	}
+
+	/**
+	 * Expiry sweep can auto-delete when configured.
+	 */
+	public function test_process_expired_deletes_when_configured(): void {
+		add_option( 'expiring_b', 'beta', '', 'no' );
+		$id = Quarantine::quarantine( 'expiring_b' );
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->update(
+			Schema::quarantine_table(),
+			array( 'expires_at' => '2020-01-01 00:00:00' ),
+			array( 'id' => $id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		update_option( Quarantine::EXPIRY_ACTION_OPTION, 'delete' );
+		$summary = Quarantine::process_expired();
+		$this->assertSame( 1, $summary['deleted'] );
+
+		$manifest = Quarantine::get_manifest( (int) $id );
+		$this->assertSame( Quarantine::STATUS_DELETED, $manifest['status'] );
+	}
+
+	/**
+	 * Expiry sweep is a no-op when expiry action is "keep".
+	 */
+	public function test_process_expired_keeps_when_configured(): void {
+		update_option( Quarantine::EXPIRY_ACTION_OPTION, 'keep' );
+		$summary = Quarantine::process_expired();
+		$this->assertSame( 0, $summary['processed'] );
+	}
+
+	/**
+	 * Configured expiry days are clamped to 1-30.
+	 */
+	public function test_configured_expiry_days_is_clamped(): void {
+		update_option( Quarantine::EXPIRY_DAYS_OPTION, 0 );
+		$this->assertSame( 1, Quarantine::configured_expiry_days() );
+		update_option( Quarantine::EXPIRY_DAYS_OPTION, 100 );
+		$this->assertSame( 30, Quarantine::configured_expiry_days() );
+		update_option( Quarantine::EXPIRY_DAYS_OPTION, 14 );
+		$this->assertSame( 14, Quarantine::configured_expiry_days() );
+	}
+}


### PR DESCRIPTION
## Summary
Implements the Quarantine module per docs/DESIGN.md §4.5.

- \`quarantine()\` renames the target row to \`_optrion_q__<name>\`, sets autoload=no, records a manifest row (original name/autoload/score/expiry/operator), rolls back the rename if the manifest insert fails
- \`restore()\` and \`delete_permanently()\` reverse the rename or drop the row; both update manifest status + stamp timestamps
- Eligibility guard rejects core options, empty / already-prefixed names, names >178 chars, and enforces the 50-item live cap
- Daily cron \`optrion_quarantine_check\` processes expired entries; action is \`restore\`/\`delete\`/\`keep\` via \`optrion_quarantine_expiry_action\` option; window configurable 1-30 days
- Clears wp_cache options/alloptions after mutations
- Cron scheduled on activation, cleared on deactivation

Closes #12

## Test plan
- [ ] CI PHPUnit green
- [ ] Manual: quarantine a test option via WP-CLI eval-file, observe it disappear from \`get_option()\`, restore, confirm autoload preserved