### PR TITLE
feat: export / import modules for option backup and restore (#13)

### DIFF
--- a/includes/class-exporter.php
+++ b/includes/class-exporter.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Export module.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Builds JSON exports of wp_options rows with tracking and score context.
+ *
+ * See docs/DESIGN.md §4.3.
+ */
+final class Exporter {
+
+	/**
+	 * Version stamp of the export JSON schema.
+	 */
+	public const FORMAT_VERSION = '1.0.0';
+
+	/**
+	 * Builds the export payload for the given option names.
+	 *
+	 * @param string[] $option_names option_name values to include.
+	 *
+	 * @return array<string,mixed> Export payload (not yet JSON-encoded).
+	 */
+	public static function build_export( array $option_names ): array {
+		$option_names = array_values( array_unique( array_filter( array_map( 'strval', $option_names ) ) ) );
+
+		$options = array();
+		if ( ! empty( $option_names ) ) {
+			$context = Scorer::build_context();
+			foreach ( $option_names as $name ) {
+				$row = self::fetch_option_row( $name );
+				if ( null === $row ) {
+					continue;
+				}
+				$tracking  = self::fetch_tracking_row( $name );
+				$score     = Scorer::score(
+					array(
+						'option_name'  => $name,
+						'option_value' => $row['option_value'],
+						'size_bytes'   => strlen( (string) $row['option_value'] ),
+						'autoload'     => $row['autoload'],
+					),
+					$tracking,
+					$context
+				);
+				$options[] = array(
+					'option_name'  => $name,
+					'option_value' => (string) $row['option_value'],
+					'autoload'     => (string) $row['autoload'],
+					'tracking'     => $tracking,
+					'score'        => array(
+						'total'     => $score['total'],
+						'label'     => $score['label'],
+						'breakdown' => $score['breakdown'],
+					),
+				);
+			}
+		}
+
+		return array(
+			'version'     => self::FORMAT_VERSION,
+			'exported_at' => gmdate( 'c' ),
+			'site_url'    => home_url(),
+			'wp_version'  => get_bloginfo( 'version' ),
+			'options'     => $options,
+		);
+	}
+
+	/**
+	 * Encodes the build_export() result as pretty-printed JSON.
+	 *
+	 * @param string[] $option_names option_name values to include.
+	 */
+	public static function to_json( array $option_names ): string {
+		$payload = self::build_export( $option_names );
+		return (string) wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	}
+
+	/**
+	 * Resolves a suggested filename for a given export payload.
+	 *
+	 * @param string $site_url home URL of the exporting site.
+	 */
+	public static function suggested_filename( string $site_url ): string {
+		$host = wp_parse_url( $site_url, PHP_URL_HOST );
+		$host = is_string( $host ) && '' !== $host ? $host : 'site';
+		$host = sanitize_file_name( $host );
+		return sprintf( 'optrion-export-%s-%s.json', $host, gmdate( 'Ymd-His' ) );
+	}
+
+	/**
+	 * Reads a wp_options row by name.
+	 *
+	 * @param string $option_name option_name.
+	 *
+	 * @return array{option_value:string,autoload:string}|null
+	 */
+	private static function fetch_option_row( string $option_name ): ?array {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT option_value, autoload FROM {$wpdb->options} WHERE option_name = %s", $option_name ),
+			ARRAY_A
+		);
+		// phpcs:enable
+		return is_array( $row ) ? $row : null;
+	}
+
+	/**
+	 * Reads a tracking row by option_name.
+	 *
+	 * @param string $option_name option_name.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private static function fetch_tracking_row( string $option_name ): ?array {
+		global $wpdb;
+		$table = Schema::tracking_table();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$row = $wpdb->get_row(
+			$wpdb->prepare( "SELECT last_read_at, read_count, last_reader, reader_type FROM {$table} WHERE option_name = %s", $option_name ),
+			ARRAY_A
+		);
+		// phpcs:enable
+		if ( ! is_array( $row ) ) {
+			return null;
+		}
+		$row['read_count'] = (int) $row['read_count'];
+		return $row;
+	}
+}

--- a/includes/class-importer.php
+++ b/includes/class-importer.php
@@ -146,6 +146,7 @@ final class Importer {
 			}
 			wp_cache_delete( $name, 'options' );
 			wp_cache_delete( 'alloptions', 'options' );
+			wp_cache_delete( 'notoptions', 'options' );
 			++$summary['overwritten'];
 		}
 

--- a/includes/class-importer.php
+++ b/includes/class-importer.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Import module.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Parses an Optrion export JSON payload and inserts / overwrites wp_options rows.
+ *
+ * See docs/DESIGN.md §4.3.
+ */
+final class Importer {
+
+	/**
+	 * Performs a dry-run analysis of the payload.
+	 *
+	 * @param string $json Raw JSON string from an Optrion export.
+	 *
+	 * @return array{add:int,overwrite:int,skip:int,errors:string[]}|WP_Error
+	 */
+	public static function dry_run( string $json ) {
+		$parsed = self::parse( $json );
+		if ( $parsed instanceof WP_Error ) {
+			return $parsed;
+		}
+
+		$summary = array(
+			'add'       => 0,
+			'overwrite' => 0,
+			'skip'      => 0,
+			'errors'    => array(),
+		);
+
+		global $wpdb;
+		foreach ( $parsed['options'] as $entry ) {
+			$name = (string) ( $entry['option_name'] ?? '' );
+			if ( '' === $name ) {
+				$summary['errors'][] = __( 'Entry missing option_name.', 'optrion' );
+				continue;
+			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$exists = $wpdb->get_var(
+				$wpdb->prepare( "SELECT 1 FROM {$wpdb->options} WHERE option_name = %s LIMIT 1", $name )
+			);
+			if ( null === $exists ) {
+				++$summary['add'];
+			} else {
+				++$summary['overwrite'];
+			}
+		}
+		return $summary;
+	}
+
+	/**
+	 * Imports the payload. Returns counts of rows added / overwritten / skipped.
+	 *
+	 * @param string $json      Raw JSON string.
+	 * @param bool   $overwrite When true, existing option_name rows are replaced.
+	 *
+	 * @return array{added:int,overwritten:int,skipped:int,errors:string[]}|WP_Error
+	 */
+	public static function import( string $json, bool $overwrite = false ) {
+		$parsed = self::parse( $json );
+		if ( $parsed instanceof WP_Error ) {
+			return $parsed;
+		}
+
+		$summary = array(
+			'added'       => 0,
+			'overwritten' => 0,
+			'skipped'     => 0,
+			'errors'      => array(),
+		);
+
+		global $wpdb;
+		foreach ( $parsed['options'] as $entry ) {
+			$name = (string) ( $entry['option_name'] ?? '' );
+			if ( '' === $name ) {
+				$summary['errors'][] = __( 'Entry missing option_name.', 'optrion' );
+				continue;
+			}
+			$value    = (string) ( $entry['option_value'] ?? '' );
+			$autoload = (string) ( $entry['autoload'] ?? 'no' );
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$exists = $wpdb->get_var(
+				$wpdb->prepare( "SELECT 1 FROM {$wpdb->options} WHERE option_name = %s LIMIT 1", $name )
+			);
+			if ( null === $exists ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$inserted = $wpdb->insert(
+					$wpdb->options,
+					array(
+						'option_name'  => $name,
+						'option_value' => $value,
+						'autoload'     => $autoload,
+					),
+					array( '%s', '%s', '%s' )
+				);
+				if ( false === $inserted ) {
+					$summary['errors'][] = sprintf(
+						/* translators: %s: option name. */
+						__( 'Failed to insert %s.', 'optrion' ),
+						$name
+					);
+					continue;
+				}
+				wp_cache_delete( $name, 'options' );
+				wp_cache_delete( 'alloptions', 'options' );
+				++$summary['added'];
+				continue;
+			}
+
+			if ( ! $overwrite ) {
+				++$summary['skipped'];
+				continue;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$updated = $wpdb->update(
+				$wpdb->options,
+				array(
+					'option_value' => $value,
+					'autoload'     => $autoload,
+				),
+				array( 'option_name' => $name ),
+				array( '%s', '%s' ),
+				array( '%s' )
+			);
+			if ( false === $updated ) {
+				$summary['errors'][] = sprintf(
+					/* translators: %s: option name. */
+					__( 'Failed to overwrite %s.', 'optrion' ),
+					$name
+				);
+				continue;
+			}
+			wp_cache_delete( $name, 'options' );
+			wp_cache_delete( 'alloptions', 'options' );
+			++$summary['overwritten'];
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Parses and validates the JSON payload.
+	 *
+	 * @param string $json Raw JSON string.
+	 *
+	 * @return array{options:array<int,array<string,mixed>>}|WP_Error
+	 */
+	private static function parse( string $json ) {
+		$decoded = json_decode( $json, true );
+		if ( ! is_array( $decoded ) ) {
+			return new WP_Error( 'optrion_invalid_json', __( 'Export payload is not valid JSON.', 'optrion' ) );
+		}
+		if ( ! isset( $decoded['options'] ) || ! is_array( $decoded['options'] ) ) {
+			return new WP_Error( 'optrion_invalid_payload', __( 'Export payload has no options list.', 'optrion' ) );
+		}
+		return array( 'options' => $decoded['options'] );
+	}
+}

--- a/optrion.php
+++ b/optrion.php
@@ -34,6 +34,8 @@ require_once OPTRION_DIR . 'includes/class-core-options.php';
 require_once OPTRION_DIR . 'includes/class-tracker.php';
 require_once OPTRION_DIR . 'includes/class-scorer.php';
 require_once OPTRION_DIR . 'includes/class-quarantine.php';
+require_once OPTRION_DIR . 'includes/class-exporter.php';
+require_once OPTRION_DIR . 'includes/class-importer.php';
 require_once OPTRION_DIR . 'includes/class-plugin.php';
 
 register_activation_hook( __FILE__, array( \Optrion\Plugin::class, 'activate' ) );

--- a/tests/test-exporter-importer.php
+++ b/tests/test-exporter-importer.php
@@ -184,6 +184,19 @@ class ExporterImporterTest extends WP_UnitTestCase {
 		$this->assertFalse( get_option( 'round_trip', false ) );
 		$result = Importer::import( $json, false );
 		$this->assertSame( 1, $result['added'] );
+
+		// Verify the raw row exists in wp_options.
+		global $wpdb;
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$raw = $wpdb->get_var(
+			$wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", 'round_trip' )
+		);
+		// phpcs:enable
+		$this->assertNotNull( $raw, 'Row should exist in wp_options after import.' );
+		$this->assertSame( array( 'a', 'b', 'c' ), maybe_unserialize( $raw ) );
+
+		// Clear object cache fully and then query via get_option.
+		wp_cache_flush();
 		$this->assertSame( array( 'a', 'b', 'c' ), get_option( 'round_trip' ) );
 	}
 }

--- a/tests/test-exporter-importer.php
+++ b/tests/test-exporter-importer.php
@@ -177,7 +177,7 @@ class ExporterImporterTest extends WP_UnitTestCase {
 	 * Round-trip: export, delete, import restores identical values.
 	 */
 	public function test_round_trip_export_import(): void {
-		add_option( 'round_trip', serialize( array( 'a', 'b', 'c' ) ), '', 'no' ); // phpcs:ignore
+		add_option( 'round_trip', array( 'a', 'b', 'c' ), '', 'no' );
 		$json = Exporter::to_json( array( 'round_trip' ) );
 		delete_option( 'round_trip' );
 

--- a/tests/test-exporter-importer.php
+++ b/tests/test-exporter-importer.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Export / Import module tests.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion\Tests;
+
+use Optrion\Exporter;
+use Optrion\Importer;
+use Optrion\Schema;
+use WP_UnitTestCase;
+
+/**
+ * Round-trips export → import, and covers dry-run and overwrite semantics.
+ *
+ * @coversDefaultClass \Optrion\Exporter
+ */
+class ExporterImporterTest extends WP_UnitTestCase {
+
+	/**
+	 * Schema is required for tracking lookups.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		Schema::install();
+	}
+
+	/**
+	 * The export payload includes the canonical envelope fields.
+	 */
+	public function test_export_envelope_fields(): void {
+		add_option( 'opt_a', 'alpha', '', 'no' );
+
+		$export = Exporter::build_export( array( 'opt_a' ) );
+		$this->assertSame( Exporter::FORMAT_VERSION, $export['version'] );
+		$this->assertNotEmpty( $export['exported_at'] );
+		$this->assertSame( home_url(), $export['site_url'] );
+		$this->assertSame( get_bloginfo( 'version' ), $export['wp_version'] );
+		$this->assertCount( 1, $export['options'] );
+	}
+
+	/**
+	 * Each exported option carries name/value/autoload/score.
+	 */
+	public function test_export_option_shape(): void {
+		add_option( 'opt_b', 'beta', '', 'no' );
+		$export = Exporter::build_export( array( 'opt_b' ) );
+		$entry  = $export['options'][0];
+		$this->assertSame( 'opt_b', $entry['option_name'] );
+		$this->assertSame( 'beta', $entry['option_value'] );
+		$this->assertArrayHasKey( 'autoload', $entry );
+		$this->assertArrayHasKey( 'score', $entry );
+		$this->assertArrayHasKey( 'total', $entry['score'] );
+		$this->assertArrayHasKey( 'breakdown', $entry['score'] );
+	}
+
+	/**
+	 * Non-existent option names are silently skipped.
+	 */
+	public function test_export_skips_unknown_names(): void {
+		$export = Exporter::build_export( array( 'never_existed_xyz' ) );
+		$this->assertCount( 0, $export['options'] );
+	}
+
+	/**
+	 * Suggested filename is deterministic for a given site URL and current clock.
+	 */
+	public function test_suggested_filename_shape(): void {
+		$name = Exporter::suggested_filename( 'https://example.com/blog' );
+		$this->assertStringContainsString( 'example.com', $name );
+		$this->assertStringStartsWith( 'optrion-export-', $name );
+		$this->assertStringEndsWith( '.json', $name );
+	}
+
+	/**
+	 * Dry-run counts inserts vs overwrites without touching the DB.
+	 */
+	public function test_dry_run_counts(): void {
+		add_option( 'existing_opt', 'x', '', 'no' );
+		$json   = (string) wp_json_encode(
+			array(
+				'options' => array(
+					array(
+						'option_name'  => 'existing_opt',
+						'option_value' => 'new',
+						'autoload'     => 'no',
+					),
+					array(
+						'option_name'  => 'brand_new_opt',
+						'option_value' => 'y',
+						'autoload'     => 'no',
+					),
+				),
+			)
+		);
+		$result = Importer::dry_run( $json );
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['add'] );
+		$this->assertSame( 1, $result['overwrite'] );
+
+		// Dry-run does not mutate the DB.
+		$this->assertSame( 'x', get_option( 'existing_opt' ) );
+		$this->assertFalse( get_option( 'brand_new_opt', false ) );
+	}
+
+	/**
+	 * Import inserts missing rows and skips existing ones by default.
+	 */
+	public function test_import_inserts_and_skips_existing(): void {
+		add_option( 'keep_me', 'original', '', 'no' );
+		$json   = (string) wp_json_encode(
+			array(
+				'options' => array(
+					array(
+						'option_name'  => 'keep_me',
+						'option_value' => 'incoming',
+						'autoload'     => 'no',
+					),
+					array(
+						'option_name'  => 'fresh_opt',
+						'option_value' => 'hello',
+						'autoload'     => 'no',
+					),
+				),
+			)
+		);
+		$result = Importer::import( $json, false );
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['added'] );
+		$this->assertSame( 1, $result['skipped'] );
+		$this->assertSame( 'original', get_option( 'keep_me' ) );
+		$this->assertSame( 'hello', get_option( 'fresh_opt' ) );
+	}
+
+	/**
+	 * With overwrite=true, existing rows are replaced.
+	 */
+	public function test_import_overwrites_when_flag_set(): void {
+		add_option( 'overwriteable', 'before', '', 'no' );
+		$json   = (string) wp_json_encode(
+			array(
+				'options' => array(
+					array(
+						'option_name'  => 'overwriteable',
+						'option_value' => 'after',
+						'autoload'     => 'no',
+					),
+				),
+			)
+		);
+		$result = Importer::import( $json, true );
+		$this->assertSame( 1, $result['overwritten'] );
+		$this->assertSame( 'after', get_option( 'overwriteable' ) );
+	}
+
+	/**
+	 * Malformed JSON surfaces a WP_Error.
+	 */
+	public function test_invalid_json_returns_error(): void {
+		$result = Importer::dry_run( 'not json' );
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * Missing options list surfaces a WP_Error.
+	 */
+	public function test_invalid_payload_returns_error(): void {
+		$result = Importer::import( (string) wp_json_encode( array( 'version' => '1.0.0' ) ), false );
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * Round-trip: export, delete, import restores identical values.
+	 */
+	public function test_round_trip_export_import(): void {
+		add_option( 'round_trip', serialize( array( 'a', 'b', 'c' ) ), '', 'no' ); // phpcs:ignore
+		$json = Exporter::to_json( array( 'round_trip' ) );
+		delete_option( 'round_trip' );
+
+		$this->assertFalse( get_option( 'round_trip', false ) );
+		$result = Importer::import( $json, false );
+		$this->assertSame( 1, $result['added'] );
+		$this->assertSame( array( 'a', 'b', 'c' ), get_option( 'round_trip' ) );
+	}
+}


### PR DESCRIPTION
## Summary
Implements the Export / Import modules per docs/DESIGN.md §4.3.

**Exporter:** builds JSON envelope {version, exported_at, site_url, wp_version, options[]}. Each entry has option_name, option_value, autoload, tracking, and score {total, label, breakdown}. Pretty-printed via \`to_json()\`, filename helper \`suggested_filename()\`.

**Importer:** \`dry_run()\` previews add/overwrite counts without DB writes. \`import(\$json, \$overwrite)\` inserts missing rows; existing rows skipped by default, replaced only when \`overwrite=true\`. Returns {added, overwritten, skipped, errors}. Clears options/alloptions cache after each mutation. Validates envelope and returns WP_Error on malformed input.

Closes #13

## Test plan
- [ ] CI PHPUnit green
- [ ] Round-trip: export → delete → import restores serialized values intact