### PR TITLE
feat: cleaner module with auto-backup and retention (#14)

### DIFF
--- a/includes/class-cleaner.php
+++ b/includes/class-cleaner.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Cleaner module.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion;
+
+use WP_Error;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Deletes wp_options rows with an automatic JSON backup and a rolling
+ * 3-generation retention window.
+ *
+ * See docs/DESIGN.md §4.4.
+ */
+final class Cleaner {
+
+	/**
+	 * Maximum number of backup files retained on disk.
+	 */
+	public const BACKUP_RETENTION = 3;
+
+	/**
+	 * Subdirectory of wp-content where backups are written.
+	 */
+	public const BACKUP_SUBDIR = 'optrion-backups';
+
+	/**
+	 * Deletes the given option names, after first writing a backup file.
+	 *
+	 * @param string[] $option_names option_name values to delete.
+	 *
+	 * @return array{deleted:int,skipped:int,backup_path:?string,errors:string[]}|WP_Error
+	 */
+	public static function delete( array $option_names ) {
+		$option_names = array_values( array_unique( array_filter( array_map( 'strval', $option_names ) ) ) );
+
+		$deletable = array();
+		$skipped   = 0;
+		$errors    = array();
+		foreach ( $option_names as $name ) {
+			if ( CoreOptions::contains( $name ) ) {
+				++$skipped;
+				$errors[] = sprintf(
+					/* translators: %s: option_name that was protected. */
+					__( 'Skipped core option: %s', 'optrion' ),
+					$name
+				);
+				continue;
+			}
+			$deletable[] = $name;
+		}
+
+		if ( empty( $deletable ) ) {
+			return array(
+				'deleted'     => 0,
+				'skipped'     => $skipped,
+				'backup_path' => null,
+				'errors'      => $errors,
+			);
+		}
+
+		$backup = self::write_backup( $deletable );
+		if ( $backup instanceof WP_Error ) {
+			return $backup;
+		}
+
+		global $wpdb;
+		$deleted_count = 0;
+		$tracking      = Schema::tracking_table();
+		foreach ( $deletable as $name ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$deleted = $wpdb->delete(
+				$wpdb->options,
+				array( 'option_name' => $name ),
+				array( '%s' )
+			);
+			if ( false === $deleted || 0 === $deleted ) {
+				$errors[] = sprintf(
+					/* translators: %s: option_name that could not be deleted. */
+					__( 'Failed to delete %s.', 'optrion' ),
+					$name
+				);
+				continue;
+			}
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->delete(
+				$tracking,
+				array( 'option_name' => $name ),
+				array( '%s' )
+			);
+			wp_cache_delete( $name, 'options' );
+			wp_cache_delete( 'alloptions', 'options' );
+			++$deleted_count;
+		}
+
+		self::prune_old_backups();
+
+		return array(
+			'deleted'     => $deleted_count,
+			'skipped'     => $skipped,
+			'backup_path' => $backup,
+			'errors'      => $errors,
+		);
+	}
+
+	/**
+	 * Writes a JSON backup for the given option names and returns its full path.
+	 *
+	 * @param string[] $option_names option_name values.
+	 *
+	 * @return string|WP_Error Absolute backup path.
+	 */
+	public static function write_backup( array $option_names ) {
+		$dir = self::backup_dir();
+		if ( ! self::ensure_dir( $dir ) ) {
+			return new WP_Error( 'optrion_backup_dir_failed', __( 'Could not create backup directory.', 'optrion' ) );
+		}
+
+		$json = Exporter::to_json( $option_names );
+		$file = trailingslashit( $dir ) . sprintf( 'optrion-backup-%s.json', gmdate( 'Ymd-His' ) );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$written = file_put_contents( $file, $json, LOCK_EX );
+		if ( false === $written ) {
+			return new WP_Error( 'optrion_backup_write_failed', __( 'Could not write backup file.', 'optrion' ) );
+		}
+		return $file;
+	}
+
+	/**
+	 * Removes backup files beyond the retention window (oldest first).
+	 */
+	public static function prune_old_backups(): void {
+		$dir   = self::backup_dir();
+		$files = glob( trailingslashit( $dir ) . 'optrion-backup-*.json' );
+		if ( ! is_array( $files ) || count( $files ) <= self::BACKUP_RETENTION ) {
+			return;
+		}
+		sort( $files );
+		$excess = count( $files ) - self::BACKUP_RETENTION;
+		for ( $i = 0; $i < $excess; $i++ ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+			@unlink( $files[ $i ] );
+		}
+	}
+
+	/**
+	 * Absolute path to the backup directory.
+	 */
+	public static function backup_dir(): string {
+		return trailingslashit( WP_CONTENT_DIR ) . self::BACKUP_SUBDIR;
+	}
+
+	/**
+	 * Ensures the given directory exists and is protected with an index.php file.
+	 *
+	 * @param string $dir Directory path.
+	 */
+	private static function ensure_dir( string $dir ): bool {
+		if ( ! is_dir( $dir ) && ! wp_mkdir_p( $dir ) ) {
+			return false;
+		}
+		$index = trailingslashit( $dir ) . 'index.php';
+		if ( ! file_exists( $index ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			@file_put_contents( $index, "<?php\n// Silence is golden.\n" );
+		}
+		return true;
+	}
+}

--- a/optrion.php
+++ b/optrion.php
@@ -36,6 +36,7 @@ require_once OPTRION_DIR . 'includes/class-scorer.php';
 require_once OPTRION_DIR . 'includes/class-quarantine.php';
 require_once OPTRION_DIR . 'includes/class-exporter.php';
 require_once OPTRION_DIR . 'includes/class-importer.php';
+require_once OPTRION_DIR . 'includes/class-cleaner.php';
 require_once OPTRION_DIR . 'includes/class-plugin.php';
 
 register_activation_hook( __FILE__, array( \Optrion\Plugin::class, 'activate' ) );

--- a/tests/test-cleaner.php
+++ b/tests/test-cleaner.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Cleaner module tests.
+ *
+ * @package Optrion
+ */
+
+declare(strict_types=1);
+
+namespace Optrion\Tests;
+
+use Optrion\Cleaner;
+use Optrion\Schema;
+use WP_UnitTestCase;
+
+/**
+ * Exercises delete + backup + retention.
+ *
+ * @coversDefaultClass \Optrion\Cleaner
+ */
+class CleanerTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensures schema exists and the backup directory starts empty.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		Schema::install();
+		$dir = Cleaner::backup_dir();
+		if ( is_dir( $dir ) ) {
+			foreach ( (array) glob( trailingslashit( $dir ) . 'optrion-backup-*.json' ) as $file ) {
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+				@unlink( $file );
+			}
+		}
+	}
+
+	/**
+	 * Deletes option rows and returns a backup path.
+	 */
+	public function test_delete_removes_rows_and_returns_backup_path(): void {
+		add_option( 'to_delete_a', 'alpha', '', 'no' );
+		add_option( 'to_delete_b', 'beta', '', 'no' );
+
+		$result = Cleaner::delete( array( 'to_delete_a', 'to_delete_b' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( 2, $result['deleted'] );
+		$this->assertNotNull( $result['backup_path'] );
+		$this->assertFileExists( $result['backup_path'] );
+
+		$this->assertFalse( get_option( 'to_delete_a', false ) );
+		$this->assertFalse( get_option( 'to_delete_b', false ) );
+	}
+
+	/**
+	 * Core options are skipped and recorded as errors.
+	 */
+	public function test_delete_skips_core_options(): void {
+		$result = Cleaner::delete( array( 'siteurl' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( 0, $result['deleted'] );
+		$this->assertSame( 1, $result['skipped'] );
+		$this->assertNotEmpty( $result['errors'] );
+		// No backup when nothing deletable remains.
+		$this->assertNull( $result['backup_path'] );
+	}
+
+	/**
+	 * Tracking rows are cleared alongside the options row.
+	 */
+	public function test_delete_also_clears_tracking_row(): void {
+		add_option( 'delete_with_tracking', 'x', '', 'no' );
+
+		global $wpdb;
+		$table = Schema::tracking_table();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->insert(
+			$table,
+			array(
+				'option_name'  => 'delete_with_tracking',
+				'last_read_at' => '2026-01-01 00:00:00',
+				'read_count'   => 5,
+				'last_reader'  => 'x',
+				'reader_type'  => 'plugin',
+				'first_seen'   => '2026-01-01 00:00:00',
+			),
+			array( '%s', '%s', '%d', '%s', '%s', '%s' )
+		);
+
+		Cleaner::delete( array( 'delete_with_tracking' ) );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE option_name = %s", 'delete_with_tracking' )
+		);
+		// phpcs:enable
+		$this->assertSame( 0, $count );
+	}
+
+	/**
+	 * Only the most recent BACKUP_RETENTION files are retained.
+	 */
+	public function test_prune_old_backups_retains_last_n(): void {
+		$dir = Cleaner::backup_dir();
+		wp_mkdir_p( $dir );
+		// Create 5 stale backup files with ascending timestamps in their names.
+		$names = array();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$path = trailingslashit( $dir ) . sprintf( 'optrion-backup-2026010%d-000000.json', $i );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			file_put_contents( $path, '{}' );
+			$names[] = $path;
+		}
+
+		Cleaner::prune_old_backups();
+
+		$remaining = (array) glob( trailingslashit( $dir ) . 'optrion-backup-*.json' );
+		$this->assertCount( Cleaner::BACKUP_RETENTION, $remaining );
+		// The oldest two should be gone, newest three should remain.
+		$this->assertFileDoesNotExist( $names[0] );
+		$this->assertFileDoesNotExist( $names[1] );
+		$this->assertFileExists( $names[2] );
+		$this->assertFileExists( $names[3] );
+		$this->assertFileExists( $names[4] );
+	}
+
+	/**
+	 * Write_backup writes a JSON file containing the exported envelope.
+	 */
+	public function test_write_backup_emits_valid_json(): void {
+		add_option( 'backup_me', 'value', '', 'no' );
+		$path = Cleaner::write_backup( array( 'backup_me' ) );
+		$this->assertIsString( $path );
+		$this->assertFileExists( $path );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$contents = file_get_contents( $path );
+		$decoded  = json_decode( $contents, true );
+		$this->assertIsArray( $decoded );
+		$this->assertArrayHasKey( 'options', $decoded );
+		$this->assertCount( 1, $decoded['options'] );
+		$this->assertSame( 'backup_me', $decoded['options'][0]['option_name'] );
+	}
+}


### PR DESCRIPTION
## Summary
Implements the Cleaner per docs/DESIGN.md §4.4.

- \`Cleaner::delete()\` writes a JSON backup via Exporter, then deletes from \`wp_options\` + tracking table; returns {deleted, skipped, backup_path, errors}
- Core options auto-skipped and reported in errors
- Backup files live in \`wp-content/optrion-backups/\` with index.php silence; 3-generation retention pruned on each pass
- Clears options/alloptions cache after each delete

Closes #14

## Test plan
- [ ] CI PHPUnit green
- [ ] Manual: delete test options on a dev site, verify backup file appears and rotates after 3 passes