### PR TITLE
fix: exclude editor/IDE dotfiles from release zip (#28)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,9 @@
 .gitignore
 .gitattributes
 .husky
+.claude
+.idea
+.vscode
 .wp-env.json
 .wp-env.override.json
 .distignore


### PR DESCRIPTION
Excludes `.claude`, `.idea`, `.vscode` from the release build so developer-local tool state does not ship with the plugin zip. Closes #28.