### PR TITLE
feat: React admin SPA with 5 tabs (#18)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,48 @@
 /**
- * Optrion admin SPA shell.
+ * Optrion admin SPA shell with tab navigation.
  */
 
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-const App = ( { config } ) => {
+import Dashboard from './tabs/Dashboard';
+import OptionsList from './tabs/OptionsList';
+import Quarantine from './tabs/Quarantine';
+import Export from './tabs/Export';
+import Import from './tabs/Import';
+
+const TABS = [
+	{ id: 'dashboard', label: __( 'Dashboard', 'optrion' ), component: Dashboard },
+	{ id: 'options', label: __( 'Options', 'optrion' ), component: OptionsList },
+	{ id: 'quarantine', label: __( 'Quarantine', 'optrion' ), component: Quarantine },
+	{ id: 'export', label: __( 'Export', 'optrion' ), component: Export },
+	{ id: 'import', label: __( 'Import', 'optrion' ), component: Import },
+];
+
+const App = () => {
+	const [ active, setActive ] = useState( 'dashboard' );
+	const Current = TABS.find( ( t ) => t.id === active ).component;
+
 	return (
 		<div className="optrion-app">
-			<p>{ __( 'Optrion UI build is ready. Dashboard components land in issue #18.', 'optrion' ) }</p>
-			<p className="optrion-app__meta">
-				{ __( 'REST base: ', 'optrion' ) }
-				<code>{ config.restRoot }</code>
-			</p>
+			<nav className="nav-tab-wrapper optrion-tabs">
+				{ TABS.map( ( tab ) => (
+					<a
+						key={ tab.id }
+						href={ '#' + tab.id }
+						className={ 'nav-tab' + ( active === tab.id ? ' nav-tab-active' : '' ) }
+						onClick={ ( e ) => {
+							e.preventDefault();
+							setActive( tab.id );
+						} }
+					>
+						{ tab.label }
+					</a>
+				) ) }
+			</nav>
+			<div className="optrion-tab-panel">
+				<Current />
+			</div>
 		</div>
 	);
 };

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,68 @@
+/**
+ * Thin wrapper around @wordpress/api-fetch scoped to the Optrion namespace.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+
+const config = window.optrionConfig || {};
+
+if ( config.nonce ) {
+	apiFetch.use( apiFetch.createNonceMiddleware( config.nonce ) );
+}
+if ( config.restRoot ) {
+	apiFetch.use( apiFetch.createRootURLMiddleware( config.restRoot ) );
+}
+
+const request = ( path, options = {} ) =>
+	apiFetch( { path: path.replace( /^\//, '' ), ...options } );
+
+export const api = {
+	stats: () => request( 'stats' ),
+	listOptions: ( query = {} ) => {
+		const usp = new URLSearchParams();
+		Object.entries( query ).forEach( ( [ k, v ] ) => {
+			if ( v !== undefined && v !== null && v !== '' ) {
+				usp.set( k, String( v ) );
+			}
+		} );
+		const q = usp.toString();
+		return request( 'options' + ( q ? '?' + q : '' ) );
+	},
+	deleteOptions: ( names ) =>
+		request( 'options', {
+			method: 'DELETE',
+			data: { names },
+		} ),
+	export: ( names, scoreMin ) =>
+		request( 'export', {
+			method: 'POST',
+			data: { names, score_min: scoreMin },
+		} ),
+	import: ( payload, overwrite ) =>
+		request( 'import', {
+			method: 'POST',
+			data: { payload, overwrite },
+		} ),
+	importPreview: ( payload ) =>
+		request( 'import/preview', {
+			method: 'POST',
+			data: { payload },
+		} ),
+	listQuarantine: ( status = 'active' ) =>
+		request( 'quarantine?status=' + encodeURIComponent( status ) ),
+	createQuarantine: ( names, days ) =>
+		request( 'quarantine', {
+			method: 'POST',
+			data: { names, days },
+		} ),
+	restoreQuarantine: ( ids ) =>
+		request( 'quarantine/restore', {
+			method: 'POST',
+			data: { ids },
+		} ),
+	deleteQuarantine: ( ids ) =>
+		request( 'quarantine', {
+			method: 'DELETE',
+			data: { ids },
+		} ),
+};

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,12 +1,94 @@
 .optrion-app {
-	background: #fff;
-	border: 1px solid #c3c4c7;
-	border-radius: 4px;
-	padding: 16px 20px;
 	margin-top: 16px;
 
-	&__meta {
-		color: #50575e;
-		font-size: 13px;
+	.optrion-tabs {
+		margin-bottom: 16px;
+	}
+
+	.optrion-tab-panel {
+		background: #fff;
+		border: 1px solid #c3c4c7;
+		border-radius: 0 4px 4px 4px;
+		padding: 16px 20px;
+	}
+
+	.optrion-error {
+		color: #b32d2e;
+		background: #fcf0f1;
+		padding: 8px 12px;
+		border-left: 4px solid #b32d2e;
+	}
+
+	.optrion-cards {
+		display: flex;
+		gap: 12px;
+		flex-wrap: wrap;
+	}
+
+	.optrion-card {
+		flex: 1 1 200px;
+		border: 1px solid #dcdcde;
+		border-radius: 4px;
+		padding: 12px 16px;
+		background: #f6f7f7;
+
+		&__label {
+			font-size: 12px;
+			color: #50575e;
+		}
+
+		&__value {
+			font-size: 24px;
+			font-weight: 600;
+			margin-top: 4px;
+		}
+	}
+
+	.optrion-filters {
+		display: flex;
+		gap: 12px;
+		align-items: flex-end;
+		margin-bottom: 12px;
+		flex-wrap: wrap;
+
+		> * {
+			flex: 0 0 180px;
+		}
+	}
+
+	.optrion-bulk {
+		display: flex;
+		gap: 8px;
+		align-items: center;
+		margin-bottom: 12px;
+
+		&__hint {
+			margin-left: auto;
+			color: #50575e;
+			font-size: 13px;
+		}
+	}
+
+	.optrion-pager {
+		display: flex;
+		gap: 12px;
+		align-items: center;
+		margin-top: 12px;
+	}
+
+	.optrion-owner-type {
+		color: #646970;
+		font-size: 11px;
+	}
+
+	.optrion-score--red { color: #b32d2e; font-weight: 600; }
+	.optrion-score--orange { color: #d98500; font-weight: 600; }
+	.optrion-score--yellow { color: #a48f00; }
+	.optrion-score--green { color: #2a6a2e; }
+
+	.optrion-import__actions {
+		display: flex;
+		gap: 8px;
+		margin: 12px 0;
 	}
 }

--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
+
+import { api } from '../api';
+
+const Dashboard = () => {
+	const [ stats, setStats ] = useState( null );
+	const [ error, setError ] = useState( null );
+
+	useEffect( () => {
+		api.stats()
+			.then( setStats )
+			.catch( ( e ) => setError( e.message || String( e ) ) );
+	}, [] );
+
+	if ( error ) {
+		return <p className="optrion-error">{ error }</p>;
+	}
+	if ( ! stats ) {
+		return <Spinner />;
+	}
+
+	const cards = [
+		{ label: __( 'Total options', 'optrion' ), value: stats.total_options },
+		{ label: __( 'Autoload payload', 'optrion' ), value: stats.autoload_total_size_human },
+	];
+
+	return (
+		<div className="optrion-dashboard">
+			<div className="optrion-cards">
+				{ cards.map( ( card ) => (
+					<div className="optrion-card" key={ card.label }>
+						<div className="optrion-card__label">{ card.label }</div>
+						<div className="optrion-card__value">{ card.value }</div>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+export default Dashboard;

--- a/src/tabs/Export.jsx
+++ b/src/tabs/Export.jsx
@@ -1,0 +1,52 @@
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, TextControl } from '@wordpress/components';
+
+import { api } from '../api';
+
+const Export = () => {
+	const [ scoreMin, setScoreMin ] = useState( '50' );
+	const [ running, setRunning ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const run = async () => {
+		setRunning( true );
+		setError( null );
+		try {
+			const payload = await api.export( [], parseInt( scoreMin, 10 ) || 0 );
+			const blob = new Blob( [ JSON.stringify( payload, null, 2 ) ], {
+				type: 'application/json',
+			} );
+			const url = URL.createObjectURL( blob );
+			const a = document.createElement( 'a' );
+			a.href = url;
+			a.download = 'optrion-export.json';
+			document.body.appendChild( a );
+			a.click();
+			a.remove();
+			URL.revokeObjectURL( url );
+		} catch ( e ) {
+			setError( e.message || String( e ) );
+		} finally {
+			setRunning( false );
+		}
+	};
+
+	return (
+		<div className="optrion-export">
+			<p>{ __( 'Export options whose score is at least this threshold.', 'optrion' ) }</p>
+			<TextControl
+				type="number"
+				label={ __( 'Score ≥', 'optrion' ) }
+				value={ scoreMin }
+				onChange={ setScoreMin }
+			/>
+			<Button variant="primary" onClick={ run } disabled={ running }>
+				{ running ? __( 'Exporting…', 'optrion' ) : __( 'Export JSON', 'optrion' ) }
+			</Button>
+			{ error && <p className="optrion-error">{ error }</p> }
+		</div>
+	);
+};
+
+export default Export;

--- a/src/tabs/Import.jsx
+++ b/src/tabs/Import.jsx
@@ -1,0 +1,91 @@
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, CheckboxControl } from '@wordpress/components';
+
+import { api } from '../api';
+
+const Import = () => {
+	const [ payload, setPayload ] = useState( '' );
+	const [ overwrite, setOverwrite ] = useState( false );
+	const [ preview, setPreview ] = useState( null );
+	const [ result, setResult ] = useState( null );
+	const [ error, setError ] = useState( null );
+	const [ busy, setBusy ] = useState( false );
+
+	const onFile = async ( event ) => {
+		const file = event.target.files[ 0 ];
+		if ( ! file ) return;
+		const text = await file.text();
+		setPayload( text );
+		setPreview( null );
+		setResult( null );
+		setError( null );
+	};
+
+	const runPreview = async () => {
+		setBusy( true );
+		setError( null );
+		try {
+			setPreview( await api.importPreview( payload ) );
+		} catch ( e ) {
+			setError( e.message || String( e ) );
+		} finally {
+			setBusy( false );
+		}
+	};
+
+	const runImport = async () => {
+		setBusy( true );
+		setError( null );
+		try {
+			setResult( await api.import( payload, overwrite ) );
+		} catch ( e ) {
+			setError( e.message || String( e ) );
+		} finally {
+			setBusy( false );
+		}
+	};
+
+	return (
+		<div className="optrion-import">
+			<p>
+				<input type="file" accept=".json,application/json" onChange={ onFile } />
+			</p>
+			<CheckboxControl
+				label={ __( 'Overwrite existing rows', 'optrion' ) }
+				checked={ overwrite }
+				onChange={ setOverwrite }
+			/>
+			<div className="optrion-import__actions">
+				<Button variant="secondary" onClick={ runPreview } disabled={ ! payload || busy }>
+					{ __( 'Dry run', 'optrion' ) }
+				</Button>
+				<Button variant="primary" onClick={ runImport } disabled={ ! payload || busy }>
+					{ __( 'Import', 'optrion' ) }
+				</Button>
+			</div>
+			{ error && <p className="optrion-error">{ error }</p> }
+			{ preview && (
+				<p>
+					{ sprintf(
+						__( 'Preview — add: %1$d, overwrite: %2$d', 'optrion' ),
+						preview.add,
+						preview.overwrite
+					) }
+				</p>
+			) }
+			{ result && (
+				<p>
+					{ sprintf(
+						__( 'Import complete — added: %1$d, overwritten: %2$d, skipped: %3$d', 'optrion' ),
+						result.added,
+						result.overwritten,
+						result.skipped
+					) }
+				</p>
+			) }
+		</div>
+	);
+};
+
+export default Import;

--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -1,0 +1,201 @@
+import { useEffect, useState, useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	Button,
+	TextControl,
+	SelectControl,
+	Spinner,
+	CheckboxControl,
+} from '@wordpress/components';
+
+import { api } from '../api';
+
+const PER_PAGE = 50;
+
+const labelClass = ( label ) => {
+	switch ( label ) {
+		case 'almost_unused':
+			return 'optrion-score--red';
+		case 'likely_unused':
+			return 'optrion-score--orange';
+		case 'review':
+			return 'optrion-score--yellow';
+		default:
+			return 'optrion-score--green';
+	}
+};
+
+const OptionsList = () => {
+	const [ items, setItems ] = useState( [] );
+	const [ total, setTotal ] = useState( 0 );
+	const [ loading, setLoading ] = useState( true );
+	const [ error, setError ] = useState( null );
+	const [ selected, setSelected ] = useState( () => new Set() );
+	const [ page, setPage ] = useState( 1 );
+	const [ search, setSearch ] = useState( '' );
+	const [ scoreMin, setScoreMin ] = useState( '' );
+	const [ ownerType, setOwnerType ] = useState( '' );
+
+	const load = useCallback( () => {
+		setLoading( true );
+		setError( null );
+		api
+			.listOptions( {
+				page,
+				per_page: PER_PAGE,
+				search,
+				score_min: scoreMin,
+				owner_type: ownerType,
+				orderby: 'score',
+				order: 'desc',
+			} )
+			.then( ( data ) => {
+				setItems( data.items || [] );
+				setTotal( data.total || 0 );
+				setSelected( new Set() );
+			} )
+			.catch( ( e ) => setError( e.message || String( e ) ) )
+			.finally( () => setLoading( false ) );
+	}, [ page, search, scoreMin, ownerType ] );
+
+	useEffect( () => {
+		load();
+	}, [ load ] );
+
+	const toggle = ( name ) => {
+		setSelected( ( prev ) => {
+			const next = new Set( prev );
+			if ( next.has( name ) ) {
+				next.delete( name );
+			} else {
+				next.add( name );
+			}
+			return next;
+		} );
+	};
+
+	const bulkDelete = () => {
+		if ( ! selected.size ) return;
+		if (
+			! window.confirm(
+				sprintf( __( 'Delete %d option(s)? (automatic backup will be made)', 'optrion' ), selected.size )
+			)
+		) {
+			return;
+		}
+		api.deleteOptions( Array.from( selected ) ).then( load );
+	};
+
+	const bulkQuarantine = () => {
+		if ( ! selected.size ) return;
+		api.createQuarantine( Array.from( selected ), 0 ).then( load );
+	};
+
+	return (
+		<div className="optrion-options-list">
+			<div className="optrion-filters">
+				<TextControl
+					label={ __( 'Search', 'optrion' ) }
+					value={ search }
+					onChange={ ( v ) => {
+						setPage( 1 );
+						setSearch( v );
+					} }
+				/>
+				<TextControl
+					type="number"
+					label={ __( 'Score ≥', 'optrion' ) }
+					value={ scoreMin }
+					onChange={ ( v ) => {
+						setPage( 1 );
+						setScoreMin( v );
+					} }
+				/>
+				<SelectControl
+					label={ __( 'Owner', 'optrion' ) }
+					value={ ownerType }
+					options={ [
+						{ label: __( 'All', 'optrion' ), value: '' },
+						{ label: 'plugin', value: 'plugin' },
+						{ label: 'theme', value: 'theme' },
+						{ label: 'core', value: 'core' },
+						{ label: 'unknown', value: 'unknown' },
+					] }
+					onChange={ ( v ) => {
+						setPage( 1 );
+						setOwnerType( v );
+					} }
+				/>
+			</div>
+			<div className="optrion-bulk">
+				<Button variant="primary" onClick={ bulkQuarantine } disabled={ ! selected.size }>
+					{ __( 'Quarantine selected', 'optrion' ) }
+				</Button>
+				<Button variant="secondary" isDestructive onClick={ bulkDelete } disabled={ ! selected.size }>
+					{ __( 'Delete selected', 'optrion' ) }
+				</Button>
+				<span className="optrion-bulk__hint">
+					{ sprintf( __( '%1$d selected · %2$d matches', 'optrion' ), selected.size, total ) }
+				</span>
+			</div>
+			{ error && <p className="optrion-error">{ error }</p> }
+			{ loading ? (
+				<Spinner />
+			) : (
+				<table className="widefat striped">
+					<thead>
+						<tr>
+							<th style={ { width: 32 } }></th>
+							<th>{ __( 'option_name', 'optrion' ) }</th>
+							<th>{ __( 'Owner', 'optrion' ) }</th>
+							<th>{ __( 'Autoload', 'optrion' ) }</th>
+							<th>{ __( 'Size', 'optrion' ) }</th>
+							<th>{ __( 'Score', 'optrion' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ items.map( ( item ) => (
+							<tr key={ item.option_name }>
+								<td>
+									<CheckboxControl
+										checked={ selected.has( item.option_name ) }
+										onChange={ () => toggle( item.option_name ) }
+									/>
+								</td>
+								<td>
+									<code>{ item.option_name }</code>
+								</td>
+								<td>
+									{ item.owner.slug || '—' }
+									<span className="optrion-owner-type"> ({ item.owner.type })</span>
+								</td>
+								<td>{ item.autoload }</td>
+								<td>{ item.size_human }</td>
+								<td className={ labelClass( item.score.label ) }>{ item.score.total }</td>
+							</tr>
+						) ) }
+					</tbody>
+				</table>
+			) }
+			<div className="optrion-pager">
+				<Button
+					disabled={ page <= 1 }
+					variant="secondary"
+					onClick={ () => setPage( ( p ) => Math.max( 1, p - 1 ) ) }
+				>
+					{ __( 'Previous', 'optrion' ) }
+				</Button>
+				<span>{ sprintf( __( 'Page %d', 'optrion' ), page ) }</span>
+				<Button
+					disabled={ items.length < PER_PAGE }
+					variant="secondary"
+					onClick={ () => setPage( ( p ) => p + 1 ) }
+				>
+					{ __( 'Next', 'optrion' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default OptionsList;

--- a/src/tabs/Quarantine.jsx
+++ b/src/tabs/Quarantine.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, SelectControl, Spinner } from '@wordpress/components';
+
+import { api } from '../api';
+
+const Quarantine = () => {
+	const [ rows, setRows ] = useState( [] );
+	const [ status, setStatus ] = useState( 'active' );
+	const [ loading, setLoading ] = useState( true );
+	const [ error, setError ] = useState( null );
+
+	const load = useCallback( () => {
+		setLoading( true );
+		setError( null );
+		api
+			.listQuarantine( status )
+			.then( ( res ) => setRows( res.items || [] ) )
+			.catch( ( e ) => setError( e.message || String( e ) ) )
+			.finally( () => setLoading( false ) );
+	}, [ status ] );
+
+	useEffect( () => {
+		load();
+	}, [ load ] );
+
+	const restore = ( id ) => {
+		api.restoreQuarantine( [ id ] ).then( load );
+	};
+	const destroy = ( id ) => {
+		if ( ! window.confirm( __( 'Permanently delete this quarantined option?', 'optrion' ) ) ) {
+			return;
+		}
+		api.deleteQuarantine( [ id ] ).then( load );
+	};
+
+	return (
+		<div className="optrion-quarantine">
+			<SelectControl
+				label={ __( 'Status', 'optrion' ) }
+				value={ status }
+				options={ [
+					{ label: __( 'Active', 'optrion' ), value: 'active' },
+					{ label: __( 'Restored', 'optrion' ), value: 'restored' },
+					{ label: __( 'Deleted', 'optrion' ), value: 'deleted' },
+				] }
+				onChange={ setStatus }
+			/>
+			{ error && <p className="optrion-error">{ error }</p> }
+			{ loading ? (
+				<Spinner />
+			) : (
+				<table className="widefat striped">
+					<thead>
+						<tr>
+							<th>{ __( 'Original name', 'optrion' ) }</th>
+							<th>{ __( 'Quarantined at', 'optrion' ) }</th>
+							<th>{ __( 'Expires at', 'optrion' ) }</th>
+							<th>{ __( 'Score', 'optrion' ) }</th>
+							<th>{ __( 'Actions', 'optrion' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						{ rows.map( ( row ) => (
+							<tr key={ row.id }>
+								<td>
+									<code>{ row.original_name }</code>
+								</td>
+								<td>{ row.quarantined_at }</td>
+								<td>{ row.expires_at }</td>
+								<td>{ row.score_at_quarantine }</td>
+								<td>
+									{ 'active' === status && (
+										<>
+											<Button variant="secondary" onClick={ () => restore( row.id ) }>
+												{ __( 'Restore', 'optrion' ) }
+											</Button>
+											<Button isDestructive onClick={ () => destroy( row.id ) }>
+												{ __( 'Delete', 'optrion' ) }
+											</Button>
+										</>
+									) }
+								</td>
+							</tr>
+						) ) }
+						{ rows.length === 0 && (
+							<tr>
+								<td colSpan="5">{ __( 'No entries.', 'optrion' ) }</td>
+							</tr>
+						) }
+					</tbody>
+				</table>
+			) }
+		</div>
+	);
+};
+
+export default Quarantine;


### PR DESCRIPTION
## Summary
Implements the admin UI described in docs/DESIGN.md §6.

- **Dashboard** — /stats cards
- **Options** — paginated table with search / score-min / owner-type filters, bulk Quarantine + Delete, colored score labels
- **Quarantine** — active/restored/deleted filter with Restore / Delete per row
- **Export** — score-threshold picker, Blob download
- **Import** — file picker, dry-run preview, overwrite toggle

API wrapper uses \`apiFetch\` + nonce middleware. Build verified locally (\`npm run build\`).

Closes #18

## Test plan
- [ ] CI green
- [ ] \`npm run build\` in wp-env, visit Tools → Optrion, exercise each tab