### PR TITLE
feat: Options tab — exclude transients, sort, last-accessed, owner fix

### DIFF
--- a/includes/class-cli-command.php
+++ b/includes/class-cli-command.php
@@ -367,6 +367,8 @@ final class CLI_Command {
 		global $wpdb;
 		$where  = array();
 		$params = array();
+		// Transients are managed by the Transient API and are out of scope.
+		$where[] = "option_name NOT LIKE '\\_transient\\_%' AND option_name NOT LIKE '\\_site\\_transient\\_%'";
 		if ( '' !== $search ) {
 			$where[]  = 'option_name LIKE %s';
 			$params[] = '%' . $wpdb->esc_like( $search ) . '%';

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -52,7 +52,7 @@ final class Rest_Controller {
 						'orderby'    => array(
 							'type'    => 'string',
 							'default' => 'score',
-							'enum'    => array( 'score', 'name', 'size', 'last_read' ),
+							'enum'    => array( 'score', 'name', 'size', 'last_read', 'owner', 'autoload' ),
 						),
 						'order'      => array(
 							'type'    => 'string',
@@ -254,6 +254,8 @@ final class Rest_Controller {
 
 		$where  = array();
 		$params = array();
+		// Transients are managed by the Transient API and are out of scope for Optrion.
+		$where[] = "option_name NOT LIKE '\\_transient\\_%' AND option_name NOT LIKE '\\_site\\_transient\\_%'";
 		if ( '' !== $search ) {
 			$where[]  = 'option_name LIKE %s';
 			$params[] = '%' . $wpdb->esc_like( $search ) . '%';
@@ -593,6 +595,12 @@ final class Rest_Controller {
 						return $sign * strcmp( (string) $a['option_name'], (string) $b['option_name'] );
 					case 'size':
 						return $sign * ( $a['size'] <=> $b['size'] );
+					case 'autoload':
+						return $sign * strcmp( (string) $a['autoload'], (string) $b['autoload'] );
+					case 'owner':
+						$oa = (string) ( $a['owner']['type'] ?? '' ) . '/' . (string) ( $a['owner']['slug'] ?? '' );
+						$ob = (string) ( $b['owner']['type'] ?? '' ) . '/' . (string) ( $b['owner']['slug'] ?? '' );
+						return $sign * strcmp( $oa, $ob );
 					case 'last_read':
 						$la = (string) ( $a['tracking']['last_read_at'] ?? '' );
 						$lb = (string) ( $b['tracking']['last_read_at'] ?? '' );
@@ -634,7 +642,11 @@ final class Rest_Controller {
 	private static function collect_names_by_score_min( int $score_min ): array {
 		global $wpdb;
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$rows = $wpdb->get_results( "SELECT option_name, option_value, autoload FROM {$wpdb->options}", ARRAY_A );
+		$rows = $wpdb->get_results(
+			"SELECT option_name, option_value, autoload FROM {$wpdb->options}"
+			. " WHERE option_name NOT LIKE '\\_transient\\_%' AND option_name NOT LIKE '\\_site\\_transient\\_%'",
+			ARRAY_A
+		);
 		// phpcs:enable
 		$tracking = self::tracking_map();
 		$context  = Scorer::build_context();

--- a/includes/class-scorer.php
+++ b/includes/class-scorer.php
@@ -137,17 +137,17 @@ final class Scorer {
 	 * @return array{type:string,slug:string}
 	 */
 	public static function infer_owner( string $option_name, ?array $tracking, array $context ): array {
-		if (
-			null !== $tracking
-			&& ! empty( $tracking['last_reader'] )
-			&& self::OWNER_TYPE_UNKNOWN !== ( $tracking['reader_type'] ?? self::OWNER_TYPE_UNKNOWN )
-		) {
+		// 1. The core registry is the strongest deterministic signal: an exact match
+		// on a curated list of WordPress-shipped option names.
+		if ( CoreOptions::contains( $option_name ) ) {
 			return array(
-				'type' => (string) $tracking['reader_type'],
-				'slug' => (string) $tracking['last_reader'],
+				'type' => self::OWNER_TYPE_CORE,
+				'slug' => 'wordpress',
 			);
 		}
 
+		// 2. Prefix matches against installed plugin/theme slugs. Prefer plugin
+		// over theme when a slug happens to exist in both.
 		foreach ( ( $context['installed_plugin_slugs'] ?? array() ) as $slug ) {
 			if ( '' !== $slug && self::name_starts_with_slug( $option_name, $slug ) ) {
 				return array(
@@ -166,10 +166,23 @@ final class Scorer {
 			}
 		}
 
-		if ( CoreOptions::contains( $option_name ) ) {
+		// 3. Tracking data is a weaker signal: "who read this option" is often
+		// WordPress core even for plugin-owned options (core loads alloptions,
+		// then plugins consume them via filters without appearing in the
+		// backtrace). Trust tracking only when it positively identifies a
+		// plugin or theme caller.
+		if (
+			null !== $tracking
+			&& ! empty( $tracking['last_reader'] )
+			&& in_array(
+				(string) ( $tracking['reader_type'] ?? '' ),
+				array( self::OWNER_TYPE_PLUGIN, self::OWNER_TYPE_THEME ),
+				true
+			)
+		) {
 			return array(
-				'type' => self::OWNER_TYPE_CORE,
-				'slug' => 'wordpress',
+				'type' => (string) $tracking['reader_type'],
+				'slug' => (string) $tracking['last_reader'],
 			);
 		}
 

--- a/includes/class-tracker.php
+++ b/includes/class-tracker.php
@@ -295,9 +295,13 @@ final class Tracker {
 			}
 		}
 
+		// No plugin / theme / core-plugin frame in the trace: we cannot say who
+		// actually owns this read. Returning 'unknown' keeps downstream owner
+		// inference honest — attributing to core here caused nearly every
+		// autoloaded option to be mis-labeled as WordPress-Core.
 		return array(
-			'type' => 'core',
-			'slug' => 'wordpress',
+			'type' => 'unknown',
+			'slug' => '',
 		);
 	}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -81,6 +81,24 @@
 		font-size: 11px;
 	}
 
+	.optrion-sort-button {
+		background: none;
+		border: 0;
+		padding: 0;
+		margin: 0;
+		font: inherit;
+		color: inherit;
+		cursor: pointer;
+		text-align: left;
+		text-decoration: underline dotted transparent;
+
+		&:hover,
+		&:focus-visible {
+			text-decoration-color: currentColor;
+			color: #2271b1;
+		}
+	}
+
 	.optrion-score--red { color: #b32d2e; font-weight: 600; }
 	.optrion-score--orange { color: #d98500; font-weight: 600; }
 	.optrion-score--yellow { color: #a48f00; }

--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -25,6 +25,28 @@ const labelClass = ( label ) => {
 	}
 };
 
+const formatLastRead = ( iso ) => {
+	if ( ! iso ) {
+		return '—';
+	}
+	// Backend returns MySQL UTC `Y-m-d H:i:s`; render in site locale.
+	const normalized = String( iso ).replace( ' ', 'T' ) + 'Z';
+	const d = new Date( normalized );
+	if ( Number.isNaN( d.getTime() ) ) {
+		return String( iso );
+	}
+	return d.toLocaleString();
+};
+
+const SORTABLE_COLUMNS = [
+	{ key: 'name', label: __( 'option_name', 'optrion' ) },
+	{ key: 'owner', label: __( 'Owner', 'optrion' ) },
+	{ key: 'autoload', label: __( 'Autoload', 'optrion' ) },
+	{ key: 'size', label: __( 'Size', 'optrion' ) },
+	{ key: 'last_read', label: __( 'Last accessed', 'optrion' ) },
+	{ key: 'score', label: __( 'Score', 'optrion' ) },
+];
+
 const OptionsList = () => {
 	const [ items, setItems ] = useState( [] );
 	const [ total, setTotal ] = useState( 0 );
@@ -35,20 +57,21 @@ const OptionsList = () => {
 	const [ search, setSearch ] = useState( '' );
 	const [ scoreMin, setScoreMin ] = useState( '' );
 	const [ ownerType, setOwnerType ] = useState( '' );
+	const [ orderby, setOrderby ] = useState( 'score' );
+	const [ order, setOrder ] = useState( 'desc' );
 
 	const load = useCallback( () => {
 		setLoading( true );
 		setError( null );
-		api
-			.listOptions( {
-				page,
-				per_page: PER_PAGE,
-				search,
-				score_min: scoreMin,
-				owner_type: ownerType,
-				orderby: 'score',
-				order: 'desc',
-			} )
+		api.listOptions( {
+			page,
+			per_page: PER_PAGE,
+			search,
+			score_min: scoreMin,
+			owner_type: ownerType,
+			orderby,
+			order,
+		} )
 			.then( ( data ) => {
 				setItems( data.items || [] );
 				setTotal( data.total || 0 );
@@ -56,7 +79,7 @@ const OptionsList = () => {
 			} )
 			.catch( ( e ) => setError( e.message || String( e ) ) )
 			.finally( () => setLoading( false ) );
-	}, [ page, search, scoreMin, ownerType ] );
+	}, [ page, search, scoreMin, ownerType, orderby, order ] );
 
 	useEffect( () => {
 		load();
@@ -78,7 +101,13 @@ const OptionsList = () => {
 		if ( ! selected.size ) return;
 		if (
 			! window.confirm(
-				sprintf( __( 'Delete %d option(s)? (automatic backup will be made)', 'optrion' ), selected.size )
+				sprintf(
+					__(
+						'Delete %d option(s)? (automatic backup will be made)',
+						'optrion'
+					),
+					selected.size
+				)
 			)
 		) {
 			return;
@@ -89,6 +118,27 @@ const OptionsList = () => {
 	const bulkQuarantine = () => {
 		if ( ! selected.size ) return;
 		api.createQuarantine( Array.from( selected ), 0 ).then( load );
+	};
+
+	const changeSort = ( key ) => {
+		setPage( 1 );
+		if ( key === orderby ) {
+			setOrder( ( v ) => ( v === 'asc' ? 'desc' : 'asc' ) );
+		} else {
+			setOrderby( key );
+			setOrder(
+				key === 'name' || key === 'owner' || key === 'autoload'
+					? 'asc'
+					: 'desc'
+			);
+		}
+	};
+
+	const sortIndicator = ( key ) => {
+		if ( key !== orderby ) {
+			return '';
+		}
+		return order === 'asc' ? ' ▲' : ' ▼';
 	};
 
 	return (
@@ -128,14 +178,27 @@ const OptionsList = () => {
 				/>
 			</div>
 			<div className="optrion-bulk">
-				<Button variant="primary" onClick={ bulkQuarantine } disabled={ ! selected.size }>
+				<Button
+					variant="primary"
+					onClick={ bulkQuarantine }
+					disabled={ ! selected.size }
+				>
 					{ __( 'Quarantine selected', 'optrion' ) }
 				</Button>
-				<Button variant="secondary" isDestructive onClick={ bulkDelete } disabled={ ! selected.size }>
+				<Button
+					variant="secondary"
+					isDestructive
+					onClick={ bulkDelete }
+					disabled={ ! selected.size }
+				>
 					{ __( 'Delete selected', 'optrion' ) }
 				</Button>
 				<span className="optrion-bulk__hint">
-					{ sprintf( __( '%1$d selected · %2$d matches', 'optrion' ), selected.size, total ) }
+					{ sprintf(
+						__( '%1$d selected · %2$d matches', 'optrion' ),
+						selected.size,
+						total
+					) }
 				</span>
 			</div>
 			{ error && <p className="optrion-error">{ error }</p> }
@@ -146,11 +209,23 @@ const OptionsList = () => {
 					<thead>
 						<tr>
 							<th style={ { width: 32 } }></th>
-							<th>{ __( 'option_name', 'optrion' ) }</th>
-							<th>{ __( 'Owner', 'optrion' ) }</th>
-							<th>{ __( 'Autoload', 'optrion' ) }</th>
-							<th>{ __( 'Size', 'optrion' ) }</th>
-							<th>{ __( 'Score', 'optrion' ) }</th>
+							{ SORTABLE_COLUMNS.map( ( col ) => (
+								<th key={ col.key }>
+									<button
+										type="button"
+										className="optrion-sort-button"
+										onClick={ () => changeSort( col.key ) }
+										aria-label={ sprintf(
+											/* translators: %s: column heading label (e.g. "Size", "Score"). */
+											__( 'Sort by %s', 'optrion' ),
+											col.label
+										) }
+									>
+										{ col.label }
+										{ sortIndicator( col.key ) }
+									</button>
+								</th>
+							) ) }
 						</tr>
 					</thead>
 					<tbody>
@@ -158,8 +233,12 @@ const OptionsList = () => {
 							<tr key={ item.option_name }>
 								<td>
 									<CheckboxControl
-										checked={ selected.has( item.option_name ) }
-										onChange={ () => toggle( item.option_name ) }
+										checked={ selected.has(
+											item.option_name
+										) }
+										onChange={ () =>
+											toggle( item.option_name )
+										}
 									/>
 								</td>
 								<td>
@@ -167,11 +246,24 @@ const OptionsList = () => {
 								</td>
 								<td>
 									{ item.owner.slug || '—' }
-									<span className="optrion-owner-type"> ({ item.owner.type })</span>
+									<span className="optrion-owner-type">
+										{ ' ' }
+										({ item.owner.type })
+									</span>
 								</td>
 								<td>{ item.autoload }</td>
 								<td>{ item.size_human }</td>
-								<td className={ labelClass( item.score.label ) }>{ item.score.total }</td>
+								<td>
+									{ formatLastRead(
+										item.tracking &&
+											item.tracking.last_read_at
+									) }
+								</td>
+								<td
+									className={ labelClass( item.score.label ) }
+								>
+									{ item.score.total }
+								</td>
 							</tr>
 						) ) }
 					</tbody>

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -83,6 +83,25 @@ class RestControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * GET /options filters out Transient API rows (_transient_* / _site_transient_*).
+	 */
+	public function test_list_options_excludes_transients(): void {
+		wp_set_current_user( $this->admin_id );
+		set_transient( 'optrion_rest_test_transient', 'x', 300 );
+		set_site_transient( 'optrion_rest_test_site_transient', 'x', 300 );
+		$req = new WP_REST_Request( 'GET', '/' . Rest_Controller::NAMESPACE_V1 . '/options' );
+		$req->set_param( 'per_page', 200 );
+		$req->set_param( 'search', 'optrion_rest_test' );
+		$response = rest_get_server()->dispatch( $req );
+		$this->assertSame( 200, $response->get_status() );
+		$names = array_column( $response->get_data()['items'], 'option_name' );
+		foreach ( $names as $name ) {
+			$this->assertStringStartsNotWith( '_transient_', (string) $name );
+			$this->assertStringStartsNotWith( '_site_transient_', (string) $name );
+		}
+	}
+
+	/**
 	 * GET /options/{name} returns 404 for unknown names.
 	 */
 	public function test_option_detail_404(): void {

--- a/tests/test-scorer.php
+++ b/tests/test-scorer.php
@@ -254,9 +254,13 @@ class ScorerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Owner inference prioritizes tracker data over prefix matching.
+	 * Owner inference prefers a plugin-slug prefix match over tracker data,
+	 * because "who read it last" is a noisier signal than the option name
+	 * itself. For options whose name does not match any installed plugin,
+	 * tracker data with a concrete plugin caller is still used — see
+	 * {@see self::test_owner_inference_falls_back_to_tracker_caller()}.
 	 */
-	public function test_owner_inference_prefers_tracker(): void {
+	public function test_owner_inference_prefers_prefix_over_tracker(): void {
 		$option   = array(
 			'option_name' => 'woocommerce_settings',
 			'size_bytes'  => 10,
@@ -269,7 +273,50 @@ class ScorerTest extends WP_UnitTestCase {
 			'reader_type'  => 'plugin',
 		);
 		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
-		$this->assertSame( 'custom-mu', $result['owner']['slug'] );
+		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
+		$this->assertSame( 'woocommerce', $result['owner']['slug'] );
+	}
+
+	/**
+	 * When no prefix / registry rule matches, a concrete plugin/theme caller
+	 * in the tracker record is used to attribute ownership.
+	 */
+	public function test_owner_inference_falls_back_to_tracker_caller(): void {
+		$option   = array(
+			'option_name' => 'opaque_blob_42',
+			'size_bytes'  => 10,
+			'autoload'    => 'no',
+		);
+		$tracking = array(
+			'last_read_at' => '2026-05-01 00:00:00',
+			'read_count'   => 3,
+			'last_reader'  => 'my-analytics',
+			'reader_type'  => 'plugin',
+		);
+		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
+		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
+		$this->assertSame( 'my-analytics', $result['owner']['slug'] );
+	}
+
+	/**
+	 * Tracker records with reader_type=core provide no information about
+	 * ownership (WordPress core reads every autoloaded option). Such rows
+	 * must not promote an option to owner=core.
+	 */
+	public function test_owner_inference_ignores_core_tracker_type(): void {
+		$option   = array(
+			'option_name' => 'opaque_blob_42',
+			'size_bytes'  => 10,
+			'autoload'    => 'yes',
+		);
+		$tracking = array(
+			'last_read_at' => '2026-05-01 00:00:00',
+			'read_count'   => 50,
+			'last_reader'  => 'wordpress',
+			'reader_type'  => 'core',
+		);
+		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
+		$this->assertSame( Scorer::OWNER_TYPE_UNKNOWN, $result['owner']['type'] );
 	}
 
 	/**

--- a/tests/test-tracker.php
+++ b/tests/test-tracker.php
@@ -69,14 +69,17 @@ class TrackerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A trace with no recognized frames is attributed to core.
+	 * A trace with no plugin/theme frames is attributed to 'unknown' (not 'core').
+	 * Returning 'core' here historically caused almost every option to be
+	 * mis-attributed to WordPress-Core in the admin UI.
 	 */
-	public function test_classify_trace_defaults_to_core(): void {
+	public function test_classify_trace_defaults_to_unknown(): void {
 		$trace  = array(
 			array( 'file' => ABSPATH . 'wp-includes/option.php' ),
 		);
 		$result = Tracker::classify_trace( $trace );
-		$this->assertSame( 'core', $result['type'] );
+		$this->assertSame( 'unknown', $result['type'] );
+		$this->assertSame( '', $result['slug'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Hide \`_transient_*\` / \`_site_transient_*\` rows (REST and WP-CLI).
- New **Last accessed** column and clickable sort on every column header (new \`orderby\` values: \`owner\`, \`autoload\`).
- Owner inference rewritten so the curated core registry and slug-prefix matches win over noisy tracker data, and \`Tracker::classify_trace()\` returns \`unknown\` (not \`core\`) when no plugin/theme frame is present. Previously this mis-labeled nearly every autoloaded option as WordPress-Core.

Closes #44, #45, #46, #47

## Test plan
- [ ] \`GET /options\` no longer returns any row whose name starts with \`_transient_\` or \`_site_transient_\`.
- [ ] Clicking each column header toggles asc/desc and the indicator arrow.
- [ ] The Last accessed column renders tracking timestamps in the browser locale and shows \`—\` when empty.
- [ ] Verify owner labels are plausible on a real site (WooCommerce options → \`woocommerce (plugin)\`, \`siteurl\` → \`wordpress (core)\`, opaque names → \`unknown\`).
- [ ] PHPUnit: \`tests/test-scorer.php\` and \`tests/test-tracker.php\` pass with the new priority order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)