### PR TITLE
ci: WP 6.9/6.8 × PHP 8.3/8.4/8.5 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           tools: composer:v2
           coverage: none
 
@@ -43,11 +43,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.1', '8.2']
-        wp: ['latest']
-        include:
-          - php: '8.1'
-            wp: '6.3'
+        php: ['8.3', '8.4', '8.5']
+        wp: ['latest', '6.8']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           tools: composer:v2
           coverage: none
 


### PR DESCRIPTION
## Summary
- PHPUnit matrix trimmed to WP \`latest\` (6.9) + \`6.8\`, and PHP \`8.3\` / \`8.4\` / \`8.5\`.
- PHPCS and release workflows bumped to PHP 8.3 to match.

Closes #52

## Test plan
- [ ] All six matrix cells run (2 WP × 3 PHP) on this PR.
- [ ] PHPCS and release workflows still boot on PHP 8.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)