### PR TITLE
feat(options): protect WordPress-Core rows from selection & deletion

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -81,6 +81,26 @@
 		font-size: 11px;
 	}
 
+	.optrion-badge {
+		display: inline-block;
+		margin-left: 6px;
+		padding: 1px 6px;
+		border-radius: 8px;
+		font-size: 10px;
+		line-height: 1.6;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+	}
+
+	.optrion-badge--protected {
+		background: #dcdcde;
+		color: #3c434a;
+	}
+
+	.optrion-row--protected td {
+		color: #646970;
+	}
+
 	.optrion-sort-button {
 		background: none;
 		border: 0;

--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -85,13 +85,18 @@ const OptionsList = () => {
 		load();
 	}, [ load ] );
 
-	const toggle = ( name ) => {
+	const isProtected = ( item ) => item && item.owner && item.owner.type === 'core';
+
+	const toggle = ( item ) => {
+		if ( isProtected( item ) ) {
+			return;
+		}
 		setSelected( ( prev ) => {
 			const next = new Set( prev );
-			if ( next.has( name ) ) {
-				next.delete( name );
+			if ( next.has( item.option_name ) ) {
+				next.delete( item.option_name );
 			} else {
-				next.add( name );
+				next.add( item.option_name );
 			}
 			return next;
 		} );
@@ -258,14 +263,28 @@ const OptionsList = () => {
 					</thead>
 					<tbody>
 						{ items.map( ( item ) => (
-							<tr key={ item.option_name }>
+							<tr
+								key={ item.option_name }
+								className={
+									isProtected( item )
+										? 'optrion-row--protected'
+										: ''
+								}
+							>
 								<td>
 									<CheckboxControl
 										checked={ selected.has(
 											item.option_name
 										) }
-										onChange={ () =>
-											toggle( item.option_name )
+										disabled={ isProtected( item ) }
+										onChange={ () => toggle( item ) }
+										aria-label={
+											isProtected( item )
+												? __(
+														'WordPress core option — protected',
+														'optrion'
+												  )
+												: undefined
 										}
 									/>
 								</td>
@@ -278,6 +297,17 @@ const OptionsList = () => {
 										{ ' ' }
 										({ item.owner.type })
 									</span>
+									{ isProtected( item ) && (
+										<span
+											className="optrion-badge optrion-badge--protected"
+											title={ __(
+												'WordPress core option — cannot be selected or deleted.',
+												'optrion'
+											) }
+										>
+											{ __( 'protected', 'optrion' ) }
+										</span>
+									) }
 								</td>
 								<td>{ item.autoload }</td>
 								<td>{ item.size_human }</td>


### PR DESCRIPTION
## Summary
- Disable the row checkbox for options whose \`owner.type === 'core'\` and short-circuit the toggle handler so core rows can never enter the selection set.
- Add a dim \`protected\` badge next to the owner label and mute the row color.
- Matches the original DESIGN.md §4 requirement to lock core options in the UI; the server-side \`Cleaner::delete()\` already refuses to drop them.

Closes #53

## Test plan
- [ ] Navigate to Options tab; rows owned by WordPress-Core show a disabled checkbox and a \`protected\` badge.
- [ ] Bulk "Delete selected" / "Quarantine selected" / "Export selected" cannot include core rows.
- [ ] Non-core rows behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)