### PR TITLE
feat(tracker): record caller file and function from stack trace

### DIFF
--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -23,7 +23,7 @@ final class Schema {
 	 *
 	 * Bump this whenever a table definition changes.
 	 */
-	public const DB_VERSION = '1.0.0';
+	public const DB_VERSION = '1.1.0';
 
 	/**
 	 * Option key that stores the installed DB version.
@@ -67,6 +67,8 @@ final class Schema {
 			last_reader varchar(255) NOT NULL DEFAULT '',
 			reader_type varchar(20) NOT NULL DEFAULT 'unknown',
 			first_seen datetime NOT NULL,
+			last_caller_file varchar(500) NOT NULL DEFAULT '',
+			last_caller_func varchar(255) NOT NULL DEFAULT '',
 			PRIMARY KEY  (option_name),
 			KEY last_read_at (last_read_at),
 			KEY reader_type (reader_type),

--- a/includes/class-tracker.php
+++ b/includes/class-tracker.php
@@ -178,23 +178,27 @@ final class Tracker {
 	/**
 	 * Records a single read into the in-memory buffer.
 	 *
-	 * @param string                         $name   Option name.
-	 * @param array{type:string,slug:string} $reader Reader classification.
-	 * @param string                         $now    MySQL-formatted UTC timestamp.
+	 * @param string                                                               $name   Option name.
+	 * @param array{type:string,slug:string,caller_file:string,caller_func:string} $reader Reader classification.
+	 * @param string                                                               $now    MySQL-formatted UTC timestamp.
 	 */
 	public static function buffer_record( string $name, array $reader, string $now ): void {
 		if ( ! isset( self::$buffer[ $name ] ) ) {
 			self::$buffer[ $name ] = array(
-				'count'  => 0,
-				'last'   => $now,
-				'reader' => $reader['slug'],
-				'type'   => $reader['type'],
+				'count'       => 0,
+				'last'        => $now,
+				'reader'      => $reader['slug'],
+				'type'        => $reader['type'],
+				'caller_file' => $reader['caller_file'] ?? '',
+				'caller_func' => $reader['caller_func'] ?? '',
 			);
 		}
 		++self::$buffer[ $name ]['count'];
-		self::$buffer[ $name ]['last']   = $now;
-		self::$buffer[ $name ]['reader'] = $reader['slug'];
-		self::$buffer[ $name ]['type']   = $reader['type'];
+		self::$buffer[ $name ]['last']        = $now;
+		self::$buffer[ $name ]['reader']      = $reader['slug'];
+		self::$buffer[ $name ]['type']        = $reader['type'];
+		self::$buffer[ $name ]['caller_file'] = $reader['caller_file'] ?? '';
+		self::$buffer[ $name ]['caller_func'] = $reader['caller_func'] ?? '';
 	}
 
 	/**
@@ -210,23 +214,27 @@ final class Tracker {
 		$placeholders = array();
 		$values       = array();
 		foreach ( self::$buffer as $name => $entry ) {
-			$placeholders[] = '(%s, %s, %d, %s, %s, %s)';
+			$placeholders[] = '(%s, %s, %d, %s, %s, %s, %s, %s)';
 			$values[]       = $name;
 			$values[]       = $entry['last'];
 			$values[]       = $entry['count'];
 			$values[]       = $entry['reader'];
 			$values[]       = $entry['type'];
 			$values[]       = $entry['last'];
+			$values[]       = $entry['caller_file'];
+			$values[]       = $entry['caller_func'];
 		}
 
 		$sql = "INSERT INTO {$table}"
-			. ' (option_name, last_read_at, read_count, last_reader, reader_type, first_seen) VALUES '
+			. ' (option_name, last_read_at, read_count, last_reader, reader_type, first_seen, last_caller_file, last_caller_func) VALUES '
 			. implode( ',', $placeholders )
 			. ' ON DUPLICATE KEY UPDATE'
 			. ' last_read_at = VALUES(last_read_at),'
 			. ' read_count = read_count + VALUES(read_count),'
 			. ' last_reader = VALUES(last_reader),'
-			. ' reader_type = VALUES(reader_type)';
+			. ' reader_type = VALUES(reader_type),'
+			. ' last_caller_file = VALUES(last_caller_file),'
+			. ' last_caller_func = VALUES(last_caller_func)';
 
 		$wpdb->query( $wpdb->prepare( $sql, $values ) ); // phpcs:ignore WordPress.DB
 
@@ -245,7 +253,7 @@ final class Tracker {
 	/**
 	 * Inspects the current PHP backtrace to attribute the caller.
 	 *
-	 * @return array{type:string,slug:string}
+	 * @return array{type:string,slug:string,caller_file:string,caller_func:string}
 	 */
 	public static function identify_caller(): array {
 		$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 15 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions
@@ -253,20 +261,24 @@ final class Tracker {
 	}
 
 	/**
-	 * Classifies a backtrace into {type, slug} based on file paths.
+	 * Classifies a backtrace into {type, slug, caller_file, caller_func}.
+	 *
+	 * `caller_file` is the path relative to the plugin / theme / WordPress root.
+	 * `caller_func` is `Class::method` for method calls or the bare function name.
 	 *
 	 * Pure function exposed for unit tests.
 	 *
-	 * @param array<int,array{file?:string}> $trace debug_backtrace() output.
-	 * @return array{type:string,slug:string}
+	 * @param array<int,array{file?:string,function?:string,class?:string}> $trace debug_backtrace() output.
+	 * @return array{type:string,slug:string,caller_file:string,caller_func:string}
 	 */
 	public static function classify_trace( array $trace ): array {
 		$plugins = self::normalize( defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : '' );
 		$mu      = self::normalize( defined( 'WPMU_PLUGIN_DIR' ) ? WPMU_PLUGIN_DIR : '' );
 		$themes  = self::normalize( function_exists( 'get_theme_root' ) ? get_theme_root() : '' );
 		$self    = self::normalize( defined( 'OPTRION_DIR' ) ? OPTRION_DIR : '' );
+		$abspath = self::normalize( defined( 'ABSPATH' ) ? ABSPATH : '' );
 
-		foreach ( $trace as $frame ) {
+		foreach ( $trace as $i => $frame ) {
 			if ( empty( $frame['file'] ) ) {
 				continue;
 			}
@@ -275,34 +287,66 @@ final class Tracker {
 			if ( '' !== $self && self::starts_with( $file, $self ) ) {
 				continue;
 			}
+
+			$type    = '';
+			$slug    = '';
+			$rel     = '';
+			$basedir = '';
+
 			if ( '' !== $plugins && self::starts_with( $file, $plugins ) ) {
-				return array(
-					'type' => 'plugin',
-					'slug' => self::extract_slug( $file, $plugins ),
-				);
+				$type    = 'plugin';
+				$slug    = self::extract_slug( $file, $plugins );
+				$basedir = $plugins;
+			} elseif ( '' !== $mu && self::starts_with( $file, $mu ) ) {
+				$type    = 'plugin';
+				$slug    = 'mu:' . self::extract_slug( $file, $mu );
+				$basedir = $mu;
+			} elseif ( '' !== $themes && self::starts_with( $file, $themes ) ) {
+				$type    = 'theme';
+				$slug    = self::extract_slug( $file, $themes );
+				$basedir = $themes;
 			}
-			if ( '' !== $mu && self::starts_with( $file, $mu ) ) {
-				return array(
-					'type' => 'plugin',
-					'slug' => 'mu:' . self::extract_slug( $file, $mu ),
-				);
+
+			if ( '' === $type ) {
+				continue;
 			}
-			if ( '' !== $themes && self::starts_with( $file, $themes ) ) {
-				return array(
-					'type' => 'theme',
-					'slug' => self::extract_slug( $file, $themes ),
-				);
-			}
+
+			$rel  = ltrim( substr( $file, strlen( $basedir ) ), '/' );
+			$func = self::frame_function( $frame );
+
+			return array(
+				'type'        => $type,
+				'slug'        => $slug,
+				'caller_file' => $rel,
+				'caller_func' => $func,
+			);
 		}
 
-		// No plugin / theme / core-plugin frame in the trace: we cannot say who
-		// actually owns this read. Returning 'unknown' keeps downstream owner
-		// inference honest — attributing to core here caused nearly every
-		// autoloaded option to be mis-labeled as WordPress-Core.
 		return array(
-			'type' => 'unknown',
-			'slug' => '',
+			'type'        => 'unknown',
+			'slug'        => '',
+			'caller_file' => '',
+			'caller_func' => '',
 		);
+	}
+
+	/**
+	 * Builds a human-readable function identifier from a backtrace frame.
+	 *
+	 * Returns `Class::method` for method calls and the bare function name
+	 * for plain functions. Returns an empty string if no function info exists.
+	 *
+	 * @param array{function?:string,class?:string} $frame Single backtrace frame.
+	 */
+	private static function frame_function( array $frame ): string {
+		if ( empty( $frame['function'] ) ) {
+			return '';
+		}
+		$func = (string) $frame['function'];
+		if ( ! empty( $frame['class'] ) ) {
+			$func = (string) $frame['class'] . '::' . $func;
+		}
+		return $func;
 	}
 
 	/**

--- a/src/index.scss
+++ b/src/index.scss
@@ -81,6 +81,17 @@
 		font-size: 11px;
 	}
 
+	.optrion-caller-info {
+		display: block;
+		color: #646970;
+		font-size: 11px;
+		max-width: 220px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		cursor: help;
+	}
+
 	.optrion-badge {
 		display: inline-block;
 		margin-left: 6px;

--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -316,6 +316,25 @@ const OptionsList = () => {
 										item.tracking &&
 											item.tracking.last_read_at
 									) }
+									{ item.tracking &&
+										item.tracking.last_caller_file && (
+										<span
+											className="optrion-caller-info"
+											title={
+												( item.tracking
+													.last_caller_func ||
+													'' ) +
+												' @ ' +
+												item.tracking
+													.last_caller_file
+											}
+										>
+											{ item.tracking
+												.last_caller_func ||
+												item.tracking
+													.last_caller_file }
+										</span>
+									) }
 								</td>
 								<td
 									className={ labelClass( item.score.label ) }

--- a/tests/test-tracker.php
+++ b/tests/test-tracker.php
@@ -36,11 +36,17 @@ class TrackerTest extends WP_UnitTestCase {
 	 */
 	public function test_classify_trace_identifies_plugin_caller(): void {
 		$trace  = array(
-			array( 'file' => WP_PLUGIN_DIR . '/woocommerce/includes/class-wc-cart.php' ),
+			array(
+				'file'     => WP_PLUGIN_DIR . '/woocommerce/includes/class-wc-cart.php',
+				'function' => 'get_cart',
+				'class'    => 'WC_Cart',
+			),
 		);
 		$result = Tracker::classify_trace( $trace );
 		$this->assertSame( 'plugin', $result['type'] );
 		$this->assertSame( 'woocommerce', $result['slug'] );
+		$this->assertSame( 'woocommerce/includes/class-wc-cart.php', $result['caller_file'] );
+		$this->assertSame( 'WC_Cart::get_cart', $result['caller_func'] );
 	}
 
 	/**
@@ -48,11 +54,16 @@ class TrackerTest extends WP_UnitTestCase {
 	 */
 	public function test_classify_trace_identifies_theme_caller(): void {
 		$trace  = array(
-			array( 'file' => get_theme_root() . '/twentytwentyfour/functions.php' ),
+			array(
+				'file'     => get_theme_root() . '/twentytwentyfour/functions.php',
+				'function' => 'theme_setup',
+			),
 		);
 		$result = Tracker::classify_trace( $trace );
 		$this->assertSame( 'theme', $result['type'] );
 		$this->assertSame( 'twentytwentyfour', $result['slug'] );
+		$this->assertSame( 'twentytwentyfour/functions.php', $result['caller_file'] );
+		$this->assertSame( 'theme_setup', $result['caller_func'] );
 	}
 
 	/**
@@ -61,17 +72,21 @@ class TrackerTest extends WP_UnitTestCase {
 	public function test_classify_trace_skips_optrion_frames(): void {
 		$trace  = array(
 			array( 'file' => OPTRION_DIR . 'includes/class-tracker.php' ),
-			array( 'file' => WP_PLUGIN_DIR . '/jetpack/jetpack.php' ),
+			array(
+				'file'     => WP_PLUGIN_DIR . '/jetpack/jetpack.php',
+				'function' => 'init',
+				'class'    => 'Jetpack',
+			),
 		);
 		$result = Tracker::classify_trace( $trace );
 		$this->assertSame( 'plugin', $result['type'] );
 		$this->assertSame( 'jetpack', $result['slug'] );
+		$this->assertSame( 'jetpack/jetpack.php', $result['caller_file'] );
+		$this->assertSame( 'Jetpack::init', $result['caller_func'] );
 	}
 
 	/**
 	 * A trace with no plugin/theme frames is attributed to 'unknown' (not 'core').
-	 * Returning 'core' here historically caused almost every option to be
-	 * mis-attributed to WordPress-Core in the admin UI.
 	 */
 	public function test_classify_trace_defaults_to_unknown(): void {
 		$trace  = array(
@@ -80,6 +95,8 @@ class TrackerTest extends WP_UnitTestCase {
 		$result = Tracker::classify_trace( $trace );
 		$this->assertSame( 'unknown', $result['type'] );
 		$this->assertSame( '', $result['slug'] );
+		$this->assertSame( '', $result['caller_file'] );
+		$this->assertSame( '', $result['caller_func'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- \`classify_trace()\` now extracts **caller_file** (relative path within plugin/theme) and **caller_func** (\`Class::method\` or function name) from the matched backtrace frame.
- Two new columns in the tracking table: \`last_caller_file VARCHAR(500)\`, \`last_caller_func VARCHAR(255)\`. DB schema bumped to 1.1.0 (dbDelta auto-upgrades).
- REST \`/options\` response includes the new fields in each \`tracking\` object.
- Options tab shows the caller as a compact sub-line under the Last accessed timestamp, with a tooltip for the full path.

Closes #56

## Test plan
- [ ] PHPUnit: \`test-tracker.php\` checks that \`classify_trace()\` returns \`caller_file\` and \`caller_func\`.
- [ ] On a site with tracking active, option reads populate \`last_caller_file\` / \`last_caller_func\` (verify via DB or REST).
- [ ] Options tab shows e.g. \`WC_Cart::get_cart\` under the last-accessed date; hovering reveals the full relative path.
- [ ] Existing rows without caller info show no sub-line (graceful empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)