### PR TITLE
feat: show plugin/theme display names from metadata headers

### DIFF
--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -307,6 +307,7 @@ final class Rest_Controller {
 					$score['owner'],
 					array(
 						'active' => self::owner_is_active( $score['owner'], $context ),
+						'name'   => Scorer::resolve_owner_name( $score['owner'], $context ),
 					)
 				),
 				'tracking'    => $tracking,
@@ -372,6 +373,7 @@ final class Rest_Controller {
 					$score['owner'],
 					array(
 						'active' => self::owner_is_active( $score['owner'], $context ),
+						'name'   => Scorer::resolve_owner_name( $score['owner'], $context ),
 					)
 				),
 				'tracking'     => $tracking,

--- a/includes/class-scorer.php
+++ b/includes/class-scorer.php
@@ -95,14 +95,18 @@ final class Scorer {
 		}
 
 		$installed_plugins = array();
+		$plugin_names      = array();
 		if ( function_exists( 'get_plugins' ) ) {
-			foreach ( array_keys( get_plugins() ) as $entry ) {
-				$installed_plugins[] = self::plugin_file_to_slug( (string) $entry );
+			foreach ( get_plugins() as $entry => $data ) {
+				$slug                  = self::plugin_file_to_slug( (string) $entry );
+				$installed_plugins[]   = $slug;
+				$plugin_names[ $slug ] = isset( $data['Name'] ) ? (string) $data['Name'] : $slug;
 			}
 		}
 
 		$active_theme_slugs    = array();
 		$installed_theme_slugs = array();
+		$theme_names           = array();
 		if ( function_exists( 'wp_get_theme' ) ) {
 			$current = wp_get_theme();
 			if ( $current && $current->exists() ) {
@@ -114,8 +118,9 @@ final class Scorer {
 			}
 		}
 		if ( function_exists( 'wp_get_themes' ) ) {
-			foreach ( wp_get_themes() as $stylesheet => $_theme ) {
-				$installed_theme_slugs[] = (string) $stylesheet;
+			foreach ( wp_get_themes() as $stylesheet => $theme_obj ) {
+				$installed_theme_slugs[]             = (string) $stylesheet;
+				$theme_names[ (string) $stylesheet ] = (string) $theme_obj->get( 'Name' );
 			}
 		}
 
@@ -124,7 +129,33 @@ final class Scorer {
 			'installed_plugin_slugs' => array_values( array_unique( $installed_plugins ) ),
 			'active_theme_slugs'     => array_values( array_unique( $active_theme_slugs ) ),
 			'installed_theme_slugs'  => array_values( array_unique( $installed_theme_slugs ) ),
+			'plugin_names'           => $plugin_names,
+			'theme_names'            => $theme_names,
 		);
+	}
+
+	/**
+	 * Resolves a human-readable display name for an owner.
+	 *
+	 * Reads Plugin Name from the plugin header or Theme Name from style.css
+	 * via the name maps built by build_context().
+	 *
+	 * @param array{type:string,slug:string}                $owner   Inferred owner.
+	 * @param array{plugin_names?:array,theme_names?:array} $context Site context.
+	 *
+	 * @return string Display name, or the raw slug if no metadata is available.
+	 */
+	public static function resolve_owner_name( array $owner, array $context ): string {
+		if ( 'core' === $owner['type'] ) {
+			return 'WordPress';
+		}
+		if ( 'plugin' === $owner['type'] && isset( $context['plugin_names'][ $owner['slug'] ] ) ) {
+			return $context['plugin_names'][ $owner['slug'] ];
+		}
+		if ( 'theme' === $owner['type'] && isset( $context['theme_names'][ $owner['slug'] ] ) ) {
+			return $context['theme_names'][ $owner['slug'] ];
+		}
+		return ! empty( $owner['slug'] ) ? $owner['slug'] : '';
 	}
 
 	/**

--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -292,7 +292,7 @@ const OptionsList = () => {
 									<code>{ item.option_name }</code>
 								</td>
 								<td>
-									{ item.owner.slug || '—' }
+									{ item.owner.name || item.owner.slug || '—' }
 									<span className="optrion-owner-type">
 										{ ' ' }
 										({ item.owner.type })

--- a/tests/test-scorer.php
+++ b/tests/test-scorer.php
@@ -45,6 +45,14 @@ class ScorerTest extends WP_UnitTestCase {
 			'installed_plugin_slugs' => array( 'woocommerce', 'old-plugin' ),
 			'active_theme_slugs'     => array( 'twentytwentyfour' ),
 			'installed_theme_slugs'  => array( 'twentytwentyfour', 'oldtheme' ),
+			'plugin_names'           => array(
+				'woocommerce' => 'WooCommerce',
+				'old-plugin'  => 'Old Plugin',
+			),
+			'theme_names'            => array(
+				'twentytwentyfour' => 'Twenty Twenty-Four',
+				'oldtheme'         => 'Old Theme',
+			),
 		);
 	}
 
@@ -317,6 +325,52 @@ class ScorerTest extends WP_UnitTestCase {
 		);
 		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
 		$this->assertSame( Scorer::OWNER_TYPE_UNKNOWN, $result['owner']['type'] );
+	}
+
+	/**
+	 * Resolve_owner_name returns the human-readable name from plugin/theme metadata.
+	 */
+	public function test_resolve_owner_name_from_metadata(): void {
+		$this->assertSame(
+			'WooCommerce',
+			Scorer::resolve_owner_name(
+				array(
+					'type' => 'plugin',
+					'slug' => 'woocommerce',
+				),
+				$this->context
+			)
+		);
+		$this->assertSame(
+			'Twenty Twenty-Four',
+			Scorer::resolve_owner_name(
+				array(
+					'type' => 'theme',
+					'slug' => 'twentytwentyfour',
+				),
+				$this->context
+			)
+		);
+		$this->assertSame(
+			'WordPress',
+			Scorer::resolve_owner_name(
+				array(
+					'type' => 'core',
+					'slug' => 'wordpress',
+				),
+				$this->context
+			)
+		);
+		$this->assertSame(
+			'',
+			Scorer::resolve_owner_name(
+				array(
+					'type' => 'unknown',
+					'slug' => '',
+				),
+				$this->context
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- \`build_context()\` now builds slug→name maps from \`get_plugins()\` (Plugin Name header) and \`wp_get_themes()\` (Theme Name from style.css).
- New \`Scorer::resolve_owner_name()\` resolves slugs to human-readable names (e.g. \`woocommerce\` → "WooCommerce", \`twentytwentyfive\` → "Twenty Twenty-Five").
- REST \`owner\` object gains a \`name\` field; the Options tab renders it instead of the raw slug.

Closes #59

## Test plan
- [ ] PHPUnit: \`test_resolve_owner_name_from_metadata\` passes.
- [ ] Options tab shows "WooCommerce (plugin)" instead of "woocommerce (plugin)", "Twenty Twenty-Five (theme)" instead of slug, and "WordPress (core)" for core rows.
- [ ] Plugins/themes without metadata fall back to the slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)