### PR TITLE
fix: dark-variant branded menu icon

### DIFF
--- a/assets/optrion-menu-icon.svg
+++ b/assets/optrion-menu-icon.svg
@@ -1,7 +1,6 @@
-<svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="10" cy="10" r="9" fill="none" stroke="#a7aaad" stroke-width="1.2"/>
-  <line x1="5" y1="5" x2="15" y2="15" stroke="#a7aaad" stroke-width="0.6" stroke-linecap="round"/>
-  <circle cx="5" cy="5" r="2" fill="#a7aaad"/>
-  <circle cx="10" cy="10" r="2.2" fill="#a7aaad"/>
-  <circle cx="15" cy="15" r="2" fill="#a7aaad"/>
+<svg width="20" height="20" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="36" cy="36" r="30" fill="none" stroke="#3c4248" stroke-width="3"/>
+  <circle cx="20" cy="21" r="7" fill="#4d8fe6"/>
+  <circle cx="36" cy="36" r="7.5" fill="#e8993e"/>
+  <circle cx="52" cy="51" r="7" fill="#e05555"/>
 </svg>


### PR DESCRIPTION
## Summary
Replace the monochrome placeholder menu icon with the official Optrion dark-variant logo (20px, no glow rings, colored dots on dark ring).

Closes #64

## Test plan
- [ ] Admin sidebar shows the colored Optrion logo (blue/amber/red dots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)