### PR TITLE
feat: guard quarantined options still being accessed from deletion

### DIFF
--- a/includes/class-quarantine.php
+++ b/includes/class-quarantine.php
@@ -237,6 +237,14 @@ final class Quarantine {
 			return new WP_Error( 'optrion_not_active', __( 'Quarantine entry is not active.', 'optrion' ) );
 		}
 
+		// Block deletion when tracking shows the option was read after quarantine.
+		if ( self::is_still_accessed( $manifest ) ) {
+			return new WP_Error(
+				'optrion_still_accessed',
+				__( 'This option is still being accessed. Restore it instead of deleting.', 'optrion' )
+			);
+		}
+
 		global $wpdb;
 		$renamed = self::RENAME_PREFIX . $manifest['original_name'];
 
@@ -410,6 +418,34 @@ final class Quarantine {
 	public static function configured_expiry_action(): string {
 		$action = (string) get_option( self::EXPIRY_ACTION_OPTION, 'restore' );
 		return in_array( $action, array( 'restore', 'delete', 'keep' ), true ) ? $action : 'restore';
+	}
+
+	/**
+	 * Explains why an option cannot be quarantined. Used for error messages.
+	 *
+	 * @param string $option_name Option name.
+	 */
+	/**
+	 * Checks whether a quarantined option is still being read.
+	 *
+	 * Returns true when the tracking table shows a last_read_at that is
+	 * more recent than the quarantine timestamp, which means something is
+	 * still trying to load the option.
+	 *
+	 * @param array{original_name:string,quarantined_at:string} $manifest Manifest row.
+	 */
+	public static function is_still_accessed( array $manifest ): bool {
+		global $wpdb;
+		$table = Schema::tracking_table();
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$last_read = $wpdb->get_var(
+			$wpdb->prepare( "SELECT last_read_at FROM {$table} WHERE option_name = %s", $manifest['original_name'] )
+		);
+		// phpcs:enable
+		if ( empty( $last_read ) || empty( $manifest['quarantined_at'] ) ) {
+			return false;
+		}
+		return $last_read > $manifest['quarantined_at'];
 	}
 
 	/**

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -502,6 +502,23 @@ final class Rest_Controller {
 			ARRAY_A
 		);
 		// phpcs:enable
+
+		// Enrich each row with tracking data so the UI can flag options that are
+		// still being accessed after quarantine.
+		$names        = wp_list_pluck( $rows, 'original_name' );
+		$tracking_map = empty( $names ) ? array() : self::tracking_map( $names );
+		foreach ( $rows as &$row ) {
+			$tracking       = $tracking_map[ $row['original_name'] ] ?? null;
+			$last_read      = $tracking ? (string) ( $tracking['last_read_at'] ?? '' ) : '';
+			$still_accessed = '' !== $last_read
+				&& '' !== $row['quarantined_at']
+				&& $last_read > $row['quarantined_at'];
+
+			$row['last_read_at']   = $last_read;
+			$row['still_accessed'] = $still_accessed;
+		}
+		unset( $row );
+
 		return new WP_REST_Response( array( 'items' => (array) $rows ) );
 	}
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -97,6 +97,11 @@
 		color: #3c434a;
 	}
 
+	.optrion-badge--warning {
+		background: #fcf0e3;
+		color: #8a6d3b;
+	}
+
 	.optrion-row--protected td {
 		color: #646970;
 	}

--- a/src/tabs/Quarantine.jsx
+++ b/src/tabs/Quarantine.jsx
@@ -28,10 +28,19 @@ const Quarantine = () => {
 		api.restoreQuarantine( [ id ] ).then( load );
 	};
 	const destroy = ( id ) => {
-		if ( ! window.confirm( __( 'Permanently delete this quarantined option?', 'optrion' ) ) ) {
+		if (
+			! window.confirm(
+				__(
+					'Permanently delete this quarantined option?',
+					'optrion'
+				)
+			)
+		) {
 			return;
 		}
-		api.deleteQuarantine( [ id ] ).then( load );
+		api.deleteQuarantine( [ id ] )
+			.then( load )
+			.catch( ( e ) => setError( e.message || String( e ) ) );
 	};
 
 	return (
@@ -41,7 +50,10 @@ const Quarantine = () => {
 				value={ status }
 				options={ [
 					{ label: __( 'Active', 'optrion' ), value: 'active' },
-					{ label: __( 'Restored', 'optrion' ), value: 'restored' },
+					{
+						label: __( 'Restored', 'optrion' ),
+						value: 'restored',
+					},
 					{ label: __( 'Deleted', 'optrion' ), value: 'deleted' },
 				] }
 				onChange={ setStatus }
@@ -56,6 +68,7 @@ const Quarantine = () => {
 							<th>{ __( 'Original name', 'optrion' ) }</th>
 							<th>{ __( 'Quarantined at', 'optrion' ) }</th>
 							<th>{ __( 'Expires at', 'optrion' ) }</th>
+							<th>{ __( 'Last accessed', 'optrion' ) }</th>
 							<th>{ __( 'Score', 'optrion' ) }</th>
 							<th>{ __( 'Actions', 'optrion' ) }</th>
 						</tr>
@@ -65,19 +78,46 @@ const Quarantine = () => {
 							<tr key={ row.id }>
 								<td>
 									<code>{ row.original_name }</code>
+									{ row.still_accessed && (
+										<span
+											className="optrion-badge optrion-badge--warning"
+											title={ __(
+												'This option was accessed after quarantine. It may still be in use.',
+												'optrion'
+											) }
+										>
+											{ __( 'still accessed', 'optrion' ) }
+										</span>
+									) }
 								</td>
 								<td>{ row.quarantined_at }</td>
 								<td>{ row.expires_at }</td>
+								<td>{ row.last_read_at || '—' }</td>
 								<td>{ row.score_at_quarantine }</td>
 								<td>
 									{ 'active' === status && (
 										<>
-											<Button variant="secondary" onClick={ () => restore( row.id ) }>
+											<Button
+												variant="secondary"
+												onClick={ () =>
+													restore( row.id )
+												}
+											>
 												{ __( 'Restore', 'optrion' ) }
 											</Button>
-											<Button isDestructive onClick={ () => destroy( row.id ) }>
-												{ __( 'Delete', 'optrion' ) }
-											</Button>
+											{ ! row.still_accessed && (
+												<Button
+													isDestructive
+													onClick={ () =>
+														destroy( row.id )
+													}
+												>
+													{ __(
+														'Delete',
+														'optrion'
+													) }
+												</Button>
+											) }
 										</>
 									) }
 								</td>
@@ -85,7 +125,9 @@ const Quarantine = () => {
 						) ) }
 						{ rows.length === 0 && (
 							<tr>
-								<td colSpan="5">{ __( 'No entries.', 'optrion' ) }</td>
+								<td colSpan="6">
+									{ __( 'No entries.', 'optrion' ) }
+								</td>
 							</tr>
 						) }
 					</tbody>


### PR DESCRIPTION
## Summary
- The quarantine list endpoint now joins tracking data and computes \`still_accessed\` (true when \`last_read_at > quarantined_at\`).
- Quarantine tab shows a **Last accessed** column and a \`still accessed\` warning badge on flagged rows.
- The **Delete** button is hidden for still-accessed entries; only **Restore** is available.
- \`Quarantine::delete_permanently()\` returns an \`optrion_still_accessed\` error on the server side as a safety net.

Closes #69

## Test plan
- [ ] Quarantine an option that is actively read (e.g. a plugin setting). After a page load (to trigger tracking), the quarantine tab shows the badge and hides the Delete button.
- [ ] Quarantine an option that is never read. Delete button is visible and works normally.
- [ ] Direct API \`DELETE /quarantine\` call for a still-accessed option returns an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)