### PR TITLE
fix: restore handles recreated options without duplicate key error

### DIFF
--- a/includes/class-core-options.php
+++ b/includes/class-core-options.php
@@ -44,6 +44,7 @@ final class CoreOptions {
 		'avatar_default',
 		'avatar_rating',
 		'blacklist_keys',
+		'can_compress_scripts',
 		'blog_charset',
 		'blog_public',
 		'blogdescription',

--- a/includes/class-quarantine.php
+++ b/includes/class-quarantine.php
@@ -186,24 +186,44 @@ final class Quarantine {
 		}
 
 		global $wpdb;
-		$renamed = self::RENAME_PREFIX . $manifest['original_name'];
+		$original = $manifest['original_name'];
+		$renamed  = self::RENAME_PREFIX . $original;
 
+		// Check whether the original option was recreated while quarantined
+		// (e.g. WordPress core re-creates missing options on the next load).
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$updated = $wpdb->update(
-			$wpdb->options,
-			array(
-				'option_name' => $manifest['original_name'],
-				'autoload'    => $manifest['original_autoload'],
-			),
-			array( 'option_name' => $renamed ),
-			array( '%s', '%s' ),
-			array( '%s' )
+		$original_exists = (bool) $wpdb->get_var(
+			$wpdb->prepare( "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name = %s", $original )
 		);
-		if ( false === $updated || 0 === $updated ) {
-			return new WP_Error( 'optrion_restore_failed', __( 'Could not rename the option row back.', 'optrion' ) );
+
+		if ( $original_exists ) {
+			// The original was recreated. Drop the quarantined copy and mark as
+			// restored since the option is already back in its rightful place.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->delete(
+				$wpdb->options,
+				array( 'option_name' => $renamed ),
+				array( '%s' )
+			);
+		} else {
+			// Normal path: rename the quarantined row back to its original name.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$updated = $wpdb->update(
+				$wpdb->options,
+				array(
+					'option_name' => $original,
+					'autoload'    => $manifest['original_autoload'],
+				),
+				array( 'option_name' => $renamed ),
+				array( '%s', '%s' ),
+				array( '%s' )
+			);
+			if ( false === $updated || 0 === $updated ) {
+				return new WP_Error( 'optrion_restore_failed', __( 'Could not rename the option row back.', 'optrion' ) );
+			}
 		}
 
-		wp_cache_delete( $manifest['original_name'], 'options' );
+		wp_cache_delete( $original, 'options' );
 		wp_cache_delete( 'alloptions', 'options' );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching


### PR DESCRIPTION
## Summary
- When restoring a quarantined option, check if the original name already exists in \`wp_options\` (recreated by core/plugin during quarantine).
- If it exists: delete the quarantined copy and mark as restored (the option is already back).
- If it doesn't: rename back as before.
- Add \`can_compress_scripts\` to the core options registry.

Closes #71

## Test plan
- [ ] Quarantine a core option (e.g. \`can_compress_scripts\`), reload, then Restore. No DB error; manifest marked as restored.
- [ ] Quarantine a non-core option, Restore works as before (rename-back).
- [ ] \`can_compress_scripts\` now shows as core/protected in the Options tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)