### PR TITLE
feat: success/error notices for all admin UI actions

### DIFF
--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -6,6 +6,7 @@ import {
 	SelectControl,
 	Spinner,
 	CheckboxControl,
+	Notice,
 } from '@wordpress/components';
 
 import { api } from '../api';
@@ -52,6 +53,7 @@ const OptionsList = () => {
 	const [ total, setTotal ] = useState( 0 );
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
+	const [ notice, setNotice ] = useState( null );
 	const [ selected, setSelected ] = useState( () => new Set() );
 	const [ page, setPage ] = useState( 1 );
 	const [ search, setSearch ] = useState( '' );
@@ -122,12 +124,32 @@ const OptionsList = () => {
 		) {
 			return;
 		}
-		api.deleteOptions( Array.from( selected ) ).then( load );
+		api.deleteOptions( Array.from( selected ) )
+			.then( ( res ) => {
+				const count = res && res.deleted ? res.deleted.length : selected.size;
+				setNotice( {
+					type: 'success',
+					/* translators: %d: number of deleted options. */
+					message: sprintf( __( '%d option(s) deleted.', 'optrion' ), count ),
+				} );
+				load();
+			} )
+			.catch( ( e ) => setNotice( { type: 'error', message: e.message || String( e ) } ) );
 	};
 
 	const bulkQuarantine = () => {
 		if ( ! selected.size ) return;
-		api.createQuarantine( Array.from( selected ), 0 ).then( load );
+		api.createQuarantine( Array.from( selected ), 0 )
+			.then( ( res ) => {
+				const count = res && res.quarantined ? res.quarantined.length : selected.size;
+				setNotice( {
+					type: 'success',
+					/* translators: %d: number of quarantined options. */
+					message: sprintf( __( '%d option(s) quarantined.', 'optrion' ), count ),
+				} );
+				load();
+			} )
+			.catch( ( e ) => setNotice( { type: 'error', message: e.message || String( e ) } ) );
 	};
 
 	const bulkExport = async () => {
@@ -145,8 +167,13 @@ const OptionsList = () => {
 			a.click();
 			a.remove();
 			URL.revokeObjectURL( url );
+			setNotice( {
+				type: 'success',
+				/* translators: %d: number of exported options. */
+				message: sprintf( __( '%d option(s) exported.', 'optrion' ), selected.size ),
+			} );
 		} catch ( e ) {
-			setError( e.message || String( e ) );
+			setNotice( { type: 'error', message: e.message || String( e ) } );
 		}
 	};
 
@@ -250,6 +277,15 @@ const OptionsList = () => {
 					) }
 				</span>
 			</div>
+			{ notice && (
+				<Notice
+					status={ notice.type }
+					isDismissible
+					onDismiss={ () => setNotice( null ) }
+				>
+					{ notice.message }
+				</Notice>
+			) }
 			{ error && <p className="optrion-error">{ error }</p> }
 			{ loading ? (
 				<Spinner />

--- a/src/tabs/Quarantine.jsx
+++ b/src/tabs/Quarantine.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, SelectControl, Spinner } from '@wordpress/components';
+import { Button, SelectControl, Spinner, Notice } from '@wordpress/components';
 
 import { api } from '../api';
 
@@ -9,6 +9,7 @@ const Quarantine = () => {
 	const [ status, setStatus ] = useState( 'active' );
 	const [ loading, setLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
+	const [ notice, setNotice ] = useState( null );
 
 	const load = useCallback( () => {
 		setLoading( true );
@@ -25,7 +26,12 @@ const Quarantine = () => {
 	}, [ load ] );
 
 	const restore = ( id ) => {
-		api.restoreQuarantine( [ id ] ).then( load );
+		api.restoreQuarantine( [ id ] )
+			.then( () => {
+				setNotice( { type: 'success', message: __( 'Option restored.', 'optrion' ) } );
+				load();
+			} )
+			.catch( ( e ) => setNotice( { type: 'error', message: e.message || String( e ) } ) );
 	};
 	const destroy = ( id ) => {
 		if (
@@ -39,12 +45,24 @@ const Quarantine = () => {
 			return;
 		}
 		api.deleteQuarantine( [ id ] )
-			.then( load )
-			.catch( ( e ) => setError( e.message || String( e ) ) );
+			.then( () => {
+				setNotice( { type: 'success', message: __( 'Option permanently deleted.', 'optrion' ) } );
+				load();
+			} )
+			.catch( ( e ) => setNotice( { type: 'error', message: e.message || String( e ) } ) );
 	};
 
 	return (
 		<div className="optrion-quarantine">
+			{ notice && (
+				<Notice
+					status={ notice.type }
+					isDismissible
+					onDismiss={ () => setNotice( null ) }
+				>
+					{ notice.message }
+				</Notice>
+			) }
 			<SelectControl
 				label={ __( 'Status', 'optrion' ) }
 				value={ status }


### PR DESCRIPTION
## Summary
- Options tab: success notices after bulk delete / quarantine / export, with item counts. Errors displayed as error notices.
- Quarantine tab: success/error notices after restore and permanent delete.
- Uses \`@wordpress/components\` \`Notice\` (dismissible, no data store needed).

Closes #76

## Test plan
- [ ] Delete options → green "N option(s) deleted." notice.
- [ ] Quarantine options → green "N option(s) quarantined." notice.
- [ ] Export options → green "N option(s) exported." notice.
- [ ] Restore quarantined → green "Option restored." notice.
- [ ] Delete quarantined → green "Option permanently deleted." notice.
- [ ] API error → red notice with error message.
- [ ] All notices are dismissible via the X button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)