### PR TITLE
fix(security): import payload limits and backup directory protection

### DIFF
--- a/includes/class-cleaner.php
+++ b/includes/class-cleaner.php
@@ -172,6 +172,11 @@ final class Cleaner {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 			@file_put_contents( $index, "<?php\n// Silence is golden.\n" );
 		}
+		$htaccess = trailingslashit( $dir ) . '.htaccess';
+		if ( ! file_exists( $htaccess ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			@file_put_contents( $htaccess, "Deny from all\n" );
+		}
 		return true;
 	}
 }

--- a/includes/class-importer.php
+++ b/includes/class-importer.php
@@ -21,6 +21,16 @@ defined( 'ABSPATH' ) || exit;
 final class Importer {
 
 	/**
+	 * Maximum accepted JSON payload size in bytes (2 MB).
+	 */
+	private const MAX_PAYLOAD_BYTES = 2 * 1024 * 1024;
+
+	/**
+	 * Maximum nesting depth for json_decode.
+	 */
+	private const MAX_JSON_DEPTH = 64;
+
+	/**
 	 * Performs a dry-run analysis of the payload.
 	 *
 	 * @param string $json Raw JSON string from an Optrion export.
@@ -161,7 +171,18 @@ final class Importer {
 	 * @return array{options:array<int,array<string,mixed>>}|WP_Error
 	 */
 	private static function parse( string $json ) {
-		$decoded = json_decode( $json, true );
+		if ( strlen( $json ) > self::MAX_PAYLOAD_BYTES ) {
+			return new WP_Error(
+				'optrion_payload_too_large',
+				sprintf(
+					/* translators: %s: human-readable size limit. */
+					__( 'Import payload exceeds the %s size limit.', 'optrion' ),
+					size_format( self::MAX_PAYLOAD_BYTES )
+				)
+			);
+		}
+
+		$decoded = json_decode( $json, true, self::MAX_JSON_DEPTH );
 		if ( ! is_array( $decoded ) ) {
 			return new WP_Error( 'optrion_invalid_json', __( 'Export payload is not valid JSON.', 'optrion' ) );
 		}


### PR DESCRIPTION
## Summary
Security hardening based on code audit (#80):

- **Import payload**: reject \`> 2 MB\` with a clear error; limit \`json_decode\` depth to 64 levels to prevent resource exhaustion.
- **Backup directory**: write \`.htaccess\` with \`Deny from all\` alongside the existing \`index.php\` to block direct download of backup JSON files on Apache.

### Audit notes (no code change needed)
- All REST endpoints are protected by \`manage_options\` capability ✅
- All SQL uses \`\$wpdb->prepare()\` correctly ✅
- Output is properly escaped (\`esc_html\`, \`esc_attr\`, \`esc_url_raw\`) ✅
- CSRF handled by WP REST nonce system ✅
- Quarantine race condition is inherent but limited to \`manage_options\` users — acceptable risk.

Closes #80

## Test plan
- [ ] Import a \`> 2 MB\` JSON file → error message about size limit.
- [ ] Import a deeply nested JSON → graceful error, no memory exhaustion.
- [ ] After a backup write, \`.htaccess\` exists in \`wp-content/optrion-backups/\`.
- [ ] Direct browser access to a backup JSON returns 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)