### PR TITLE
refactor: rename owner to accessor throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ Every plugin and theme writes settings to the `wp_options` table. When you deact
 
 Over time your options table accumulates hundreds of orphaned rows, many with `autoload = yes`, quietly inflating every single page load. There's no built-in way to tell which rows are still in use, which plugin created them, or whether it's safe to remove them.
 
-**Optrion fixes this.** It observes which options are actually read, identifies their owner, calculates a staleness score, and lets you safely quarantine or remove the dead weight — with full backup and one-click restore.
+**Optrion fixes this.** It observes which options are actually read, identifies their last accessor, calculates a staleness score, and lets you safely quarantine or remove the dead weight — with full backup and one-click restore.
 
 ## Features
 
 - **Read tracking** — hooks into `alloptions` and `option_{$name}` filters to record when each option was last read and by which plugin or theme.
-- **Owner detection** — traces `get_option()` call stacks back to the originating plugin/theme directory. Falls back to prefix-matching against installed plugins.
-- **Staleness scoring** — rates every option 0–100 based on owner activity, read recency, transient status, autoload waste, and data size.
+- **Accessor detection** — traces `get_option()` call stacks back to the originating plugin/theme directory. Falls back to prefix-matching against installed plugins.
+- **Staleness scoring** — rates every option 0–100 based on accessor activity, read recency, transient status, autoload waste, and data size.
 - **Quarantine mode** — renames options instead of deleting them. If something breaks, restore with one click. Auto-restores on expiry (safe by default).
-- **Bulk cleanup** — delete by score threshold, by owner, or expired transients only. Every delete auto-creates a JSON backup.
+- **Bulk cleanup** — delete by score threshold, by accessor, or expired transients only. Every delete auto-creates a JSON backup.
 - **Export / Import** — full JSON backup with option values, tracking metadata, and scores. Import with dry-run preview and optional overwrite.
-- **Dashboard** — React-based admin UI with score distribution charts, autoload size metrics, and owner breakdown.
+- **Dashboard** — React-based admin UI with score distribution charts, autoload size metrics, and accessor breakdown.
 - **WP-CLI support** — every operation available from the command line.
 - **Core protection** — ~60 known WordPress core options are hardcoded as undeletable.
 
@@ -74,7 +74,7 @@ Each option is scored across five axes:
 
 | Axis | Max Points | Condition |
 |------|-----------|-----------|
-| **Owner status** | 40 | Owning plugin/theme is deactivated (40) or owner unknown (20) |
+| **Accessor status** | 40 | Accessing plugin/theme is deactivated (40) or accessor unknown (20) |
 | **Read recency** | 25 | Last read 90+ days ago (5 pts per 30 days, capped at 25). No read recorded = 25 |
 | **Transient** | 10 | Option name starts with `_transient_` or `_site_transient_` |
 | **Autoload waste** | 15 | `autoload = yes` but zero reads during tracking period |
@@ -93,7 +93,7 @@ Total is capped at 100. The UI maps scores to four tiers:
 
 Not sure if an option is safe to delete? **Quarantine it first.**
 
-Quarantine renames the option in `wp_options` (e.g. `wpseo_titles` → `_optrion_q__wpseo_titles`) and sets `autoload` to `no`. WordPress and the owning plugin will behave as if the option doesn't exist.
+Quarantine renames the option in `wp_options` (e.g. `wpseo_titles` → `_optrion_q__wpseo_titles`) and sets `autoload` to `no`. WordPress and the accessing plugin will behave as if the option doesn't exist.
 
 ```
 Quarantine ──▶ Run your site for a few days
@@ -162,7 +162,7 @@ All endpoints require the `manage_options` capability.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/options` | List options with tracking data and scores. Supports `page`, `per_page`, `orderby`, `order`, `score_min`, `score_max`, `owner_type`, `search`. |
+| `GET` | `/options` | List options with tracking data and scores. Supports `page`, `per_page`, `orderby`, `order`, `score_min`, `score_max`, `accessor_type`, `search`. |
 | `GET` | `/options/{name}` | Single option detail |
 | `DELETE` | `/options` | Bulk delete (auto-backup) |
 | `GET` | `/stats` | Summary statistics |

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,657 @@
+# Optrion — プラグイン設計書
+
+## 1. 概要
+
+WordPress の `wp_options` テーブルには、プラグインやテーマが設定値を書き込むが、それらを停止・削除しても行が残り続ける。本プラグインは「どのオプションが、いつ、誰に読まれたか」を記録し、不要度をスコアリングすることで、管理者が安全にクリーンアップできる仕組みを提供する。
+
+### 解決する課題
+
+- 無効化・削除済みプラグイン/テーマのオプションがゴミとして残留する
+- `autoload = yes` の肥大化によるページロード時間の悪化
+- どのオプションが安全に消せるか判断する手段がない
+- 消してしまった後の復旧手段がない
+
+### 基本方針
+
+- **観察 → 判断 → 検疫 → 削除** の4段階で安全に運用できる設計
+- 追跡はサンプリング制御し、本番サイトのパフォーマンスを犠牲にしない
+- 削除の前に「検疫（リネームによる一時無効化）」を挟み、影響を事前確認できる
+- 削除前に必ず JSON エクスポートを挟むことで復旧可能性を担保
+
+---
+
+## 2. アーキテクチャ全体図
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    WordPress Core                    │
+│                                                     │
+│  get_option()  ──→  option_{$name} フィルタ          │
+│  alloptions    ──→  alloptions フィルタ              │
+│                        │                             │
+│                        ▼                             │
+│              ┌──────────────────┐                    │
+│              │  Tracker モジュール │                   │
+│              │  (読み込み追跡)    │                    │
+│              └────────┬─────────┘                    │
+│                       │ shutdown 時バッチ書込          │
+│                       ▼                              │
+│         ┌───────────────────────────┐                │
+│         │  wp_options_tracking テーブル │               │
+│         │  (カスタムテーブル)           │               │
+│         └──────────┬────────────────┘                │
+│                    │                                 │
+│         ┌──────────▼────────────────┐                │
+│         │  Scorer モジュール          │                │
+│         │  (不要度スコアリング)        │                │
+│         └──────────┬────────────────┘                │
+│                    │                                 │
+│                    ├──────────────────────┐          │
+│                    ▼                      ▼          │
+│         ┌────────────────┐   ┌─────────────────┐    │
+│         │ Cleaner (削除)  │   │ Quarantine (検疫) │   │
+│         └────────────────┘   │ リネームで一時隔離  │   │
+│                              │ 期限付き自動復元    │   │
+│                              └─────────────────┘    │
+│                    │                                 │
+│         ┌──────────▼────────────────┐                │
+│         │  REST API エンドポイント    │                │
+│         │  /wp-json/optrion/v1/*       │                │
+│         └──────────┬────────────────┘                │
+│                    │                                 │
+└────────────────────┼────────────────────────────────┘
+                     │
+          ┌──────────▼────────────────┐
+          │   管理画面ダッシュボード     │
+          │   (React SPA)              │
+          │   一覧 / 検疫 / 削除 /      │
+          │   エクスポート / インポート   │
+          └────────────────────────────┘
+```
+
+---
+
+## 3. データベース設計
+
+### 3.1 カスタムテーブル: `{prefix}_options_tracking`
+
+wp_options 自体は改変せず、追跡情報を別テーブルで管理する。
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| `option_name` | VARCHAR(191) PK | wp_options の option_name と 1:1 対応 |
+| `last_read_at` | DATETIME NULL | 最後に `get_option()` で読み込まれた日時 |
+| `read_count` | BIGINT UNSIGNED | 累計読み込み回数（追跡有効期間中） |
+| `last_reader` | VARCHAR(255) | 最後に読み込んだプラグイン/テーマのスラッグ |
+| `reader_type` | ENUM('plugin','theme','core','unknown') | 読み込み元の種別 |
+| `first_seen` | DATETIME | このテーブルに初めて記録された日時 |
+
+インデックス: `last_read_at`, `reader_type`, `read_count`
+
+### 3.2 カスタムテーブル: `{prefix}_options_quarantine`
+
+検疫中オプションの管理テーブル。詳細は「4.5 Quarantine」セクションを参照。
+
+### 3.3 wp_options 側の参照カラム（既存・読み取り専用）
+
+スコアリング時に `wp_options` から直接取得する情報:
+
+- `option_value` → シリアライズ後のバイト数
+- `autoload` → yes/no（WordPress 6.6 以降は `auto`, `on`, `off` も）
+
+---
+
+## 4. モジュール設計
+
+### 4.1 Tracker（読み込み追跡モジュール）
+
+#### 目的
+
+`get_option()` が呼ばれるたびに「いつ・誰が」読んだかを記録する。
+
+#### フック戦略
+
+WordPress には全オプション共通の `pre_option` フックが存在しないため、2系統でカバーする。
+
+| 対象 | フック | 説明 |
+|---|---|---|
+| autoload=yes のオプション群 | `alloptions` フィルタ | WordPress が全 autoload オプションをまとめて読む時点で一括検知 |
+| autoload=no の個別オプション | `option_{$name}` フィルタ（動的登録） | admin_init 時に非 autoload オプション名一覧を取得し、ループで動的にフィルタ登録 |
+
+#### 呼び出し元の特定
+
+`debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 15)` で呼び出しスタックをたどり、ファイルパスから所属を判定する。
+
+```
+判定ロジック:
+  ファイルパスが WP_PLUGIN_DIR 以下  → type=plugin, slug=ディレクトリ名
+  ファイルパスが get_theme_root() 以下 → type=theme,  slug=ディレクトリ名
+  上記いずれでもない                  → type=core
+```
+
+#### パフォーマンス制御
+
+- 追跡はメモリ上にバッファし、`shutdown` アクションで一括 DB 書き込み（1リクエスト1回のI/O）
+- `ON DUPLICATE KEY UPDATE` で upsert し、クエリ数を最小化
+- 追跡有効/無効は Transient フラグで制御。管理画面アクセス時に自動的に10分間有効化
+- WP-CLI やCron では無効化（`DOING_CRON` 定数で判定）
+- 本番運用時はサンプリングレート（例: 10%のリクエストのみ追跡）をオプション設定に追加
+
+#### 追跡の限界（設計上の前提）
+
+- 常時追跡ではないため read_count は「追跡期間中の近似値」である
+- `last_read_at = NULL` は「読み込みが記録されていない」であり「一度も読まれていない」ではない
+- この前提はスコアリングロジックと管理画面の表示の両方に反映する
+
+### 4.2 Scorer（スコアリングモジュール）
+
+#### 目的
+
+各オプション行の「不要である可能性」を 0–100 の数値で表す。
+
+#### スコア算出ルール
+
+| 評価軸 | 最大点 | 条件 |
+|---|---|---|
+| **アクセス元の状態** | 40 | アクセス元プラグインが無効=40 / アクセス元テーマが無効=40 / アクセス元不明=20 / 有効=0 |
+| **最終読み込みの鮮度** | 25 | 90日以上前: 5点/30日ごとに加算（上限25） / 記録なし=25 |
+| **Transient 判定** | 10 | `_transient_` or `_site_transient_` プレフィックス=10 |
+| **Autoload 浪費** | 15 | `autoload=yes` かつ `read_count=0`（追跡期間中）=15 |
+| **データサイズ** | 10 | 100KB超=10 / 10KB超=5 / それ以下=0 |
+
+合計を `min(100, total)` でクリップする。
+
+#### アクセス元推定ロジック
+
+`get_option()` の PHP バックトレースおよび option_name のプレフィックスから、最終アクセス元を推定する。
+
+```
+推定の優先順位:
+  1. WordPress コアオプションの既知リストとの照合（確定的シグナル）
+  2. widget_ プレフィックスによるウィジェット判定（確定的シグナル）
+  3. Tracker の last_reader（実測データ。reader_type が plugin/theme の場合のみ採用）
+  4. option_name プレフィックスとプラグインスラッグの前方一致
+  5. option_name プレフィックスとテーマスラッグの前方一致
+  6. いずれにも該当しない → unknown
+```
+
+コアオプションの既知リストは WordPress Codex の Options Reference に準拠し、siteurl, home, blogname, active_plugins, template, stylesheet, cron, rewrite_rules 等の約60個をハードコードする。
+
+#### スコア区分ラベル
+
+| スコア範囲 | ラベル | 色 | 推奨アクション |
+|---|---|---|---|
+| 0–19 | 安全 | 緑 | 放置 |
+| 20–49 | 要確認 | 黄 | 定期的に再確認 |
+| 50–79 | 不要の可能性が高い | 橙 | まず検疫 → 問題なければ本削除 |
+| 80–100 | ほぼ確実に不要 | 赤 | 検疫 or エクスポート後に即削除 |
+
+### 4.3 Export / Import（バックアップモジュール）
+
+#### エクスポート JSON フォーマット
+
+```json
+{
+  "version": "1.0.0",
+  "exported_at": "2026-04-05T12:00:00+09:00",
+  "site_url": "https://example.com",
+  "wp_version": "6.8",
+  "options": [
+    {
+      "option_name": "some_plugin_setting",
+      "option_value": "serialized_or_raw_value",
+      "autoload": "yes",
+      "tracking": {
+        "last_read_at": "2025-12-01 10:30:00",
+        "read_count": 42,
+        "last_reader": "some-plugin",
+        "reader_type": "plugin"
+      },
+      "score": {
+        "total": 75,
+        "reasons": [
+          "プラグイン「some-plugin」は無効 (+40)",
+          "最終読み込み 120 日前 (+20)",
+          "autoload=yes だが未読 (+15)"
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### エクスポート仕様
+
+- 対象: 選択したオプション or スコア閾値以上を一括
+- ファイル名: `optrion-export-{site}-{date}.json`
+- 値はシリアライズされた状態のまま保存（復元時にそのまま INSERT できるように）
+
+#### インポート仕様
+
+- JSON を読み込み、`option_name` が存在しない場合のみ INSERT（既存値は上書きしない）
+- 上書きモード（既存値を復元で上書き）はチェックボックスで明示的に選択
+- インポート前にドライランを表示（追加/上書き/スキップの件数プレビュー）
+- tracking データは参考として表示するが、復元時にはトラッキングテーブルには書き込まない
+
+### 4.4 Cleaner（削除モジュール）
+
+#### 削除フロー
+
+```
+管理者が削除対象を選択
+        │
+        ▼
+  自動エクスポート（JSON を wp-content/optrion-backups/ に保存）
+        │
+        ▼
+  確認ダイアログ（対象件数・スコア内訳を表示）
+        │
+        ▼
+  wp_options から DELETE + tracking テーブルからも DELETE
+        │
+        ▼
+  完了通知（削除件数 + バックアップファイルパスを表示）
+```
+
+#### 一括削除オプション
+
+- 「スコア N 以上をすべて削除」
+- 「期限切れ Transient をすべて削除」
+- 「特定プラグイン/テーマに属するオプションをすべて削除」
+
+#### セーフガード
+
+- WordPress コアオプション（既知リスト）は削除ボタンを無効化し、UI にロックアイコンを表示
+- autoload 合計サイズの変動を削除前後で表示（「autoload データが 1.2MB → 0.8MB に削減」）
+- 直近バックアップ3世代を `wp-content/optrion-backups/` に保持。4世代目以降は古い順に自動削除
+
+### 4.5 Quarantine（検疫モード）
+
+#### 目的
+
+「たぶん不要だが、消すと何が壊れるかわからない」オプションを、削除せずに一時的に無効化して影響を確認する仕組み。問題が出れば即座に復元でき、問題がなければそのまま本削除へ進める。
+
+#### 仕組み
+
+`option_name` をリネームすることで、WordPress コアや該当プラグインからは「存在しない」状態にする。値・autoload 設定はそのまま DB 上に残る。
+
+```
+隔離時:
+  wpseo_titles  →  _optrion_q__wpseo_titles
+
+復元時:
+  _optrion_q__wpseo_titles  →  wpseo_titles
+```
+
+リネームと同時に `autoload` を `no` に変更し、隔離中のオプションがメモリを消費しないようにする。元の autoload 値はマニフェストに記録しておき、復元時に戻す。
+
+#### 検疫マニフェスト
+
+隔離中のオプションを管理する専用テーブル `{prefix}_options_quarantine`:
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| `id` | BIGINT AUTO_INCREMENT PK | 検疫 ID |
+| `original_name` | VARCHAR(191) UNIQUE | 元の option_name |
+| `original_autoload` | VARCHAR(20) | 隔離前の autoload 値（復元用） |
+| `quarantined_at` | DATETIME | 隔離した日時 |
+| `expires_at` | DATETIME | 自動復元の期限（デフォルト: 7日後） |
+| `quarantined_by` | BIGINT | 操作した管理者の user ID |
+| `score_at_quarantine` | INT | 隔離時点のスコア |
+| `status` | ENUM('active','restored','deleted') | 現在の状態 |
+| `restored_at` | DATETIME NULL | 復元した日時 |
+| `deleted_at` | DATETIME NULL | 本削除した日時 |
+| `notes` | TEXT | 管理者メモ（任意） |
+
+#### 操作フロー
+
+```
+管理者がオプションを選択して「検疫」を実行
+        │
+        ▼
+  wp_options 上で option_name をリネーム
+  autoload を 'no' に変更
+  マニフェストに記録（元の名前・autoload・期限）
+        │
+        ▼
+  サイトを通常運用（隔離されたオプションは get_option で取得不可）
+        │
+        ├── 問題が発生した場合 ──→ 「復元」ボタン
+        │                          option_name を元に戻す
+        │                          autoload を元に戻す
+        │                          マニフェストの status を 'restored' に
+        │
+        ├── 問題なし・確信を得た ──→ 「本削除」ボタン
+        │                          リネームされた行を DELETE
+        │                          マニフェストの status を 'deleted' に
+        │
+        └── 期限切れ（何もしなかった場合）
+            ↓
+           自動復元（安全側に倒す）
+           管理画面に通知バナー表示
+           「7日間問題なかったので本削除を検討してください」
+```
+
+#### 期限と自動復元
+
+- デフォルト検疫期間: **7日間**（設定画面で 1〜30日に変更可能）
+- 期限切れ時の動作は選択式:
+  - **自動復元**（デフォルト・安全）: 元に戻し、管理者に通知
+  - **自動削除**（上級者向け）: JSON バックアップを作成した上で DELETE
+  - **放置**（期限を無期限に）: 手動で判断するまで隔離状態を維持
+- 自動処理は WordPress Cron（`optrion_quarantine_check`）で日次実行
+
+#### 検疫の制限事項
+
+- WordPress コアオプション（既知リスト）は検疫対象外（ロック表示）
+- `active_plugins`, `template`, `stylesheet`, `cron` 等の重要オプションは追加で保護
+- 一度に検疫できる上限: **50件**（大量の同時隔離による事故を防止）
+- `_optrion_q__` プレフィックスが付いた option_name は合計191文字以内である必要がある。元の名前が178文字を超える場合は検疫不可とし、その旨をUIで表示
+
+#### 検疫一覧の UI 表示
+
+オプション一覧テーブルとは別に、「検疫中」タブを設ける:
+
+| 列 | 内容 |
+|---|---|
+| 元の option_name | リネーム前の名前 |
+| アクセス元 | プラグイン/テーマ名 |
+| 隔離日時 | いつ検疫したか |
+| 残り期間 | 自動復元/削除までのカウントダウン |
+| 隔離時スコア | 検疫実行時のスコア |
+| メモ | 管理者が付けたメモ（編集可能） |
+| 操作 | 「復元」「本削除」「期間延長」ボタン |
+
+管理画面のヘッダーに常時表示するバッジ: 「検疫中: N件」
+
+#### WP-CLI 対応
+
+```bash
+# オプションを検疫（デフォルト7日間）
+wp optrion quarantine wpseo_titles wpseo_social --days=14
+
+# 検疫中オプション一覧
+wp optrion quarantine list
+
+# 復元
+wp optrion quarantine restore wpseo_titles
+
+# 検疫から本削除
+wp optrion quarantine delete wpseo_titles --yes
+
+# 期限切れチェック（Cron と同等の手動実行）
+wp optrion quarantine check-expiry
+```
+
+---
+
+## 5. REST API 設計
+
+ベース: `/wp-json/optrion/v1`
+
+権限: すべてのエンドポイントで `manage_options` 権限を要求。
+
+| メソッド | パス | 説明 | 主なパラメータ |
+|---|---|---|---|
+| GET | `/options` | オプション一覧（追跡情報・スコア付き） | `page`, `per_page`, `orderby`, `order`, `score_min`, `score_max`, `accessor_type`, `search` |
+| GET | `/options/{name}` | 単一オプションの詳細 | — |
+| DELETE | `/options` | 一括削除（自動バックアップ付き） | `names[]` |
+| GET | `/stats` | サマリー統計（合計件数、autoload サイズ、スコア分布） | — |
+| POST | `/export` | 選択オプションを JSON エクスポート | `names[]` or `score_min` |
+| POST | `/import` | JSON インポート | `file`（multipart）, `overwrite`（bool） |
+| POST | `/import/preview` | インポートのドライラン | `file`（multipart） |
+| POST | `/scan` | トラッキングの手動スナップショット実行 | — |
+| POST | `/quarantine` | 選択オプションを検疫（リネーム） | `names[]`, `days`（期限日数） |
+| GET | `/quarantine` | 検疫中オプション一覧 | `status`（active/restored/deleted） |
+| POST | `/quarantine/restore` | 検疫から復元 | `names[]` |
+| DELETE | `/quarantine` | 検疫から本削除 | `names[]` |
+| PATCH | `/quarantine/{name}` | 期間延長・メモ更新 | `days`, `notes` |
+
+### レスポンス例: `GET /options`
+
+```json
+{
+  "items": [
+    {
+      "option_name": "wpseo_titles",
+      "autoload": "yes",
+      "size": 15234,
+      "size_human": "14.9 KB",
+      "accessor": {
+        "slug": "wordpress-seo",
+        "type": "plugin",
+        "active": false
+      },
+      "tracking": {
+        "last_read_at": null,
+        "read_count": 0,
+        "last_reader": "",
+        "reader_type": "unknown"
+      },
+      "score": {
+        "total": 80,
+        "label": "ほぼ確実に不要",
+        "reasons": ["..."]
+      }
+    }
+  ],
+  "total": 342,
+  "autoload_total_size": 1258000,
+  "autoload_total_size_human": "1.2 MB"
+}
+```
+
+---
+
+## 6. 管理画面 UI 設計
+
+### 6.1 画面構成
+
+WordPress 管理メニューにトップレベル項目として「Optrion」を追加（専用ロゴアイコン付き）。
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Optrion                                                │
+├──────────────┬────────────────┬────────┬─────────────────────────┤
+│ ダッシュボード │ オプション一覧 │ 検疫中 │ インポート              │
+└──────────────┴────────────────┴────────┴─────────────────────────┘
+```
+
+エクスポートは独立タブを持たず、オプション一覧テーブルの一括操作として
+「Export selected」ボタンから実行する。
+
+### 6.2 ダッシュボード
+
+サマリーカード5枚を上部に横並び表示:
+
+| カード | 表示内容 |
+|---|---|
+| 総オプション数 | `wp_options` の総行数 |
+| Autoload サイズ | `autoload=yes` の合計バイト数 |
+| 不要の可能性（スコア50+） | 該当件数とそのサイズ合計 |
+| 期限切れ Transient | 有効期限を過ぎた transient の件数 |
+| 検疫中 | 現在隔離中のオプション件数（期限切れ間近のものは警告色） |
+
+下部にチャート2種:
+
+- **スコア分布ヒストグラム**: 横軸=スコア区分、縦軸=件数
+- **アクセス元別オプション数**: プラグイン/テーマごとの棒グラフ（有効/無効で色分け）
+
+### 6.3 オプション一覧
+
+データテーブル形式。各行に表示する列:
+
+| 列 | 内容 |
+|---|---|
+| チェックボックス | 一括操作用 |
+| option_name | クリックで値のプレビューモーダルを表示 |
+| アクセス元 | プラグイン/テーマ名 + 有効/無効バッジ |
+| Autoload | yes/no バッジ |
+| サイズ | バイト数（人間可読表記） |
+| 最終読み込み | 相対日時（例: 「3ヶ月前」） |
+| 読み込み回数 | 数値 |
+| スコア | 数値 + 色付きバー |
+| 操作 | 検疫ボタン / 削除ボタン / エクスポートボタン |
+
+フィルタバー:
+- テキスト検索（option_name 部分一致）
+- スコア範囲スライダー
+- アクセス元種別（プラグイン / テーマ / コア / 不明）
+- Autoload（yes / no / すべて）
+
+一括操作:
+- 選択項目を検疫
+- 選択項目を削除
+- 選択項目をエクスポート
+
+### 6.4 値プレビューモーダル
+
+option_name をクリックすると表示:
+
+- `option_value` の内容（配列/オブジェクトなら整形表示）
+- スコアの内訳（reason の一覧）
+- 読み込み履歴の概要
+- 「削除」「エクスポート」ボタン
+
+### 6.5 エクスポート
+
+エクスポート専用画面は存在しない。オプション一覧テーブルで選択した行を
+一括操作バーの「Export selected」ボタンから JSON ファイルとしてダウンロードする。
+スコア閾値でのエクスポートは WP-CLI（`wp optrion export --score-min=N`）を利用する。
+
+### 6.6 インポート画面
+
+- JSON ファイルをアップロード
+- ドライラン結果をテーブルで表示（追加 / 上書き / スキップの件数と一覧）
+- 上書きモードの ON/OFF
+- 「インポート実行」→ 結果サマリー表示
+
+---
+
+## 7. セキュリティ設計
+
+| 観点 | 対策 |
+|---|---|
+| 権限 | 全操作に `manage_options` ケーパビリティ必須 |
+| CSRF | REST API は WordPress 標準の nonce 認証（`X-WP-Nonce`） |
+| SQL インジェクション | `$wpdb->prepare()` を全クエリで使用 |
+| ファイル操作 | バックアップディレクトリに `.htaccess` で直接アクセス禁止 |
+| インポート検証 | JSON スキーマバリデーション。version フィールドの存在確認。option_name の文字種チェック（英数字・アンダースコア・ハイフンのみ） |
+| コアオプション保護 | 既知のコアオプション約60個はハードコードしたリストで DELETE を拒否 |
+
+---
+
+## 8. パフォーマンス設計
+
+| 懸念点 | 対策 |
+|---|---|
+| `debug_backtrace` のコスト | フレーム数を15に制限。IGNORE_ARGS フラグで引数コピーを抑制 |
+| 毎リクエストの DB 書き込み | メモリバッファ → shutdown で1回の upsert |
+| 非 autoload オプションのフック登録 | admin_init 時のみ実行。フロントエンドでは登録しない |
+| 大量オプション（数千行）の一覧取得 | REST API でページネーション（デフォルト50件/ページ）。スコア計算はリクエスト時にオンデマンド |
+| 追跡のオーバーヘッド | Transient フラグで有効/無効を制御。サンプリングレート設定（設定画面で 1–100% を指定） |
+
+---
+
+## 9. WP-CLI 対応
+
+管理画面を使わない運用向けに、WP-CLI サブコマンドも提供する。
+
+```bash
+# オプション一覧（スコア付き、閾値フィルタ）
+wp optrion list --score-min=50 --format=table
+
+# 統計サマリー
+wp optrion stats
+
+# スコア50以上を JSON エクスポート
+wp optrion export --score-min=50 --output=backup.json
+
+# JSON インポート（ドライラン）
+wp optrion import backup.json --dry-run
+
+# JSON インポート（実行）
+wp optrion import backup.json
+
+# スコア80以上を一括削除（自動バックアップ付き）
+wp optrion clean --score-min=80 --yes
+
+# 期限切れ Transient 一括削除
+wp optrion clean-transients
+
+# 手動スキャン実行
+wp optrion scan
+```
+
+---
+
+## 10. ファイル構成
+
+```
+optrion/
+├── optrion.php          # メインプラグインファイル（ブートストラップ）
+├── readme.txt                      # WordPress.org 形式の readme
+├── uninstall.php                   # アンインストール時のクリーンアップ
+│
+├── includes/
+│   ├── class-tracker.php           # Tracker モジュール
+│   ├── class-scorer.php            # Scorer モジュール
+│   ├── class-exporter.php          # Export 機能
+│   ├── class-importer.php          # Import 機能
+│   ├── class-cleaner.php           # 削除処理
+│   ├── class-quarantine.php        # 検疫モード
+│   ├── class-rest-controller.php   # REST API 定義
+│   ├── class-admin-page.php        # 管理画面の登録・アセット読み込み
+│   ├── class-cli-command.php       # WP-CLI サブコマンド
+│   └── core-options-list.php       # コアオプションの既知リスト（配列定数）
+│
+├── assets/
+│   ├── js/
+│   │   └── admin-app.js            # React ダッシュボード（ビルド済み）
+│   └── css/
+│       └── admin.css               # 管理画面用スタイル
+│
+├── src/                            # React ソース（ビルド前）
+│   ├── App.jsx
+│   ├── pages/
+│   │   ├── Dashboard.jsx
+│   │   ├── OptionsList.jsx
+│   │   ├── Quarantine.jsx
+│   │   ├── Export.jsx
+│   │   └── Import.jsx
+│   └── components/
+│       ├── ScoreBadge.jsx
+│       ├── AccessorBadge.jsx
+│       ├── OptionPreviewModal.jsx
+│       ├── ScoreChart.jsx
+│       └── AccessorChart.jsx
+│
+├── languages/
+│   └── optrion-ja.po
+│
+└── tests/
+    ├── test-scorer.php
+    ├── test-tracker.php
+    └── test-exporter.php
+```
+
+---
+
+## 11. ライフサイクル
+
+| イベント | 処理内容 |
+|---|---|
+| **有効化** | カスタムテーブル作成（tracking + quarantine）。全オプションの初回スナップショット |
+| **日常運用** | 管理画面アクセス時に追跡を自動有効化。shutdown でバッチ記録 |
+| **無効化** | Cron ジョブの解除のみ。テーブル・データは保持 |
+| **アンインストール** | カスタムテーブル DROP。バックアップディレクトリ削除。プラグイン自身のオプション削除（皮肉にならないよう確実に） |
+
+---
+
+## 12. 今後の拡張案
+
+- **差分レポートメール**: 週次で「新規に検出された不要オプション」をメール通知
+- **マルチサイト対応**: `wp_sitemeta` テーブルの同等スキャン
+- **REST API ログ連携**: Query Monitor 等の開発ツールとの統合
+- **オプションサイズの時系列推移**: autoload 合計サイズを日次で記録し、肥大化傾向をグラフ化
+- **ホワイトリスト管理**: 「このオプションは残す」と明示的にマークし、スコアリング対象外にする機能

--- a/includes/class-cli-command.php
+++ b/includes/class-cli-command.php
@@ -34,8 +34,8 @@ final class CLI_Command {
 	 * [--score-max=<int>]
 	 * : Maximum score threshold.
 	 *
-	 * [--owner-type=<type>]
-	 * : Filter by owner type.
+	 * [--accessor-type=<type>]
+	 * : Filter by accessor type.
 	 * ---
 	 * options:
 	 *   - plugin
@@ -64,13 +64,13 @@ final class CLI_Command {
 	 */
 	public function list( array $args, array $assoc_args ): void {
 		unset( $args );
-		$score_min  = isset( $assoc_args['score-min'] ) ? (int) $assoc_args['score-min'] : null;
-		$score_max  = isset( $assoc_args['score-max'] ) ? (int) $assoc_args['score-max'] : null;
-		$owner_type = isset( $assoc_args['owner-type'] ) ? (string) $assoc_args['owner-type'] : '';
-		$search     = isset( $assoc_args['search'] ) ? (string) $assoc_args['search'] : '';
-		$format     = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
+		$score_min     = isset( $assoc_args['score-min'] ) ? (int) $assoc_args['score-min'] : null;
+		$score_max     = isset( $assoc_args['score-max'] ) ? (int) $assoc_args['score-max'] : null;
+		$accessor_type = isset( $assoc_args['accessor-type'] ) ? (string) $assoc_args['accessor-type'] : '';
+		$search        = isset( $assoc_args['search'] ) ? (string) $assoc_args['search'] : '';
+		$format        = isset( $assoc_args['format'] ) ? (string) $assoc_args['format'] : 'table';
 
-		$items = self::collect_scored_rows( $score_min, $score_max, $owner_type, $search );
+		$items = self::collect_scored_rows( $score_min, $score_max, $accessor_type, $search );
 
 		if ( 'ids' === $format ) {
 			WP_CLI::log( implode( "\n", array_column( $items, 'option_name' ) ) );
@@ -80,7 +80,7 @@ final class CLI_Command {
 		Utils\format_items(
 			$format,
 			$items,
-			array( 'option_name', 'score', 'label', 'owner_type', 'owner_slug', 'autoload', 'size_bytes', 'last_read_at' )
+			array( 'option_name', 'score', 'label', 'accessor_type', 'accessor_slug', 'autoload', 'size_bytes', 'last_read_at' )
 		);
 	}
 
@@ -358,12 +358,12 @@ final class CLI_Command {
 	 *
 	 * @param int|null $score_min  Minimum score.
 	 * @param int|null $score_max  Maximum score.
-	 * @param string   $owner_type Owner type filter.
+	 * @param string   $accessor_type Accessor type filter.
 	 * @param string   $search     Substring filter.
 	 *
 	 * @return array<int,array<string,mixed>>
 	 */
-	private static function collect_scored_rows( ?int $score_min, ?int $score_max, string $owner_type, string $search ): array {
+	private static function collect_scored_rows( ?int $score_min, ?int $score_max, string $accessor_type, string $search ): array {
 		global $wpdb;
 		$where  = array();
 		$params = array();
@@ -411,18 +411,18 @@ final class CLI_Command {
 			if ( null !== $score_max && $s['total'] > $score_max ) {
 				continue;
 			}
-			if ( '' !== $owner_type && $owner_type !== $s['owner']['type'] ) {
+			if ( '' !== $accessor_type && $accessor_type !== $s['accessor']['type'] ) {
 				continue;
 			}
 			$out[] = array(
-				'option_name'  => $name,
-				'score'        => $s['total'],
-				'label'        => $s['label'],
-				'owner_type'   => $s['owner']['type'],
-				'owner_slug'   => $s['owner']['slug'],
-				'autoload'     => (string) $row['autoload'],
-				'size_bytes'   => $size,
-				'last_read_at' => (string) ( $t['last_read_at'] ?? '' ),
+				'option_name'   => $name,
+				'score'         => $s['total'],
+				'label'         => $s['label'],
+				'accessor_type' => $s['accessor']['type'],
+				'accessor_slug' => $s['accessor']['slug'],
+				'autoload'      => (string) $row['autoload'],
+				'size_bytes'    => $size,
+				'last_read_at'  => (string) ( $t['last_read_at'] ?? '' ),
 			);
 		}
 		return $out;

--- a/includes/class-core-options.php
+++ b/includes/class-core-options.php
@@ -15,8 +15,8 @@ defined( 'ABSPATH' ) || exit;
  * Static registry of option names that WordPress core itself manages.
  *
  * The list is used by the Scorer (see docs/DESIGN.md §4.2) to classify
- * an option as `owner=core`, and by the Cleaner / Quarantine modules to
- * lock out destructive operations on core-owned rows.
+ * an option as `accessor=core`, and by the Cleaner / Quarantine modules to
+ * lock out destructive operations on core rows.
  *
  * Sourced from the WordPress Codex "Option Reference" page; entries are
  * the stable option names registered by WordPress core on a fresh install.

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -41,35 +41,35 @@ final class Rest_Controller {
 					'callback'            => array( self::class, 'list_options' ),
 					'permission_callback' => $auth,
 					'args'                => array(
-						'page'       => array(
+						'page'          => array(
 							'type'    => 'integer',
 							'default' => 1,
 						),
-						'per_page'   => array(
+						'per_page'      => array(
 							'type'    => 'integer',
 							'default' => 50,
 						),
-						'orderby'    => array(
+						'orderby'       => array(
 							'type'    => 'string',
 							'default' => 'score',
-							'enum'    => array( 'score', 'name', 'size', 'last_read', 'owner', 'autoload' ),
+							'enum'    => array( 'score', 'name', 'size', 'last_read', 'accessor', 'autoload' ),
 						),
-						'order'      => array(
+						'order'         => array(
 							'type'    => 'string',
 							'default' => 'desc',
 							'enum'    => array( 'asc', 'desc' ),
 						),
-						'score_min'  => array(
+						'score_min'     => array(
 							'type' => 'integer',
 						),
-						'score_max'  => array(
+						'score_max'     => array(
 							'type' => 'integer',
 						),
-						'owner_type' => array(
+						'accessor_type' => array(
 							'type' => 'string',
 							'enum' => array( 'plugin', 'theme', 'core', 'widget', 'unknown' ),
 						),
-						'search'     => array(
+						'search'        => array(
 							'type' => 'string',
 						),
 					),
@@ -244,13 +244,13 @@ final class Rest_Controller {
 	 */
 	public static function list_options( WP_REST_Request $req ): WP_REST_Response {
 		global $wpdb;
-		$page       = max( 1, (int) $req['page'] );
-		$per_page   = min( 200, max( 1, (int) $req['per_page'] ) );
-		$offset     = ( $page - 1 ) * $per_page;
-		$search     = (string) $req['search'];
-		$score_min  = null !== $req['score_min'] ? (int) $req['score_min'] : null;
-		$score_max  = null !== $req['score_max'] ? (int) $req['score_max'] : null;
-		$owner_type = (string) $req['owner_type'];
+		$page          = max( 1, (int) $req['page'] );
+		$per_page      = min( 200, max( 1, (int) $req['per_page'] ) );
+		$offset        = ( $page - 1 ) * $per_page;
+		$search        = (string) $req['search'];
+		$score_min     = null !== $req['score_min'] ? (int) $req['score_min'] : null;
+		$score_max     = null !== $req['score_max'] ? (int) $req['score_max'] : null;
+		$accessor_type = (string) $req['accessor_type'];
 
 		$where  = array();
 		$params = array();
@@ -299,7 +299,7 @@ final class Rest_Controller {
 			if ( null !== $score_max && $score['total'] > $score_max ) {
 				continue;
 			}
-			if ( '' !== $owner_type && $owner_type !== $score['owner']['type'] ) {
+			if ( '' !== $accessor_type && $accessor_type !== $score['accessor']['type'] ) {
 				continue;
 			}
 			$items[] = array(
@@ -307,11 +307,11 @@ final class Rest_Controller {
 				'autoload'    => (string) $row['autoload'],
 				'size'        => $size,
 				'size_human'  => size_format( $size ),
-				'owner'       => array_merge(
-					$score['owner'],
+				'accessor'    => array_merge(
+					$score['accessor'],
 					array(
-						'active' => self::owner_is_active( $score['owner'], $context ),
-						'name'   => Scorer::resolve_owner_name( $score['owner'], $context ),
+						'active' => self::accessor_is_active( $score['accessor'], $context ),
+						'name'   => Scorer::resolve_accessor_name( $score['accessor'], $context ),
 					)
 				),
 				'tracking'    => $tracking,
@@ -373,11 +373,11 @@ final class Rest_Controller {
 				'autoload'     => (string) $row['autoload'],
 				'size'         => $size,
 				'size_human'   => size_format( $size ),
-				'owner'        => array_merge(
-					$score['owner'],
+				'accessor'     => array_merge(
+					$score['accessor'],
 					array(
-						'active' => self::owner_is_active( $score['owner'], $context ),
-						'name'   => Scorer::resolve_owner_name( $score['owner'], $context ),
+						'active' => self::accessor_is_active( $score['accessor'], $context ),
+						'name'   => Scorer::resolve_accessor_name( $score['accessor'], $context ),
 					)
 				),
 				'tracking'     => $tracking,
@@ -620,9 +620,9 @@ final class Rest_Controller {
 						return $sign * ( $a['size'] <=> $b['size'] );
 					case 'autoload':
 						return $sign * strcmp( (string) $a['autoload'], (string) $b['autoload'] );
-					case 'owner':
-						$oa = (string) ( $a['owner']['type'] ?? '' ) . '/' . (string) ( $a['owner']['slug'] ?? '' );
-						$ob = (string) ( $b['owner']['type'] ?? '' ) . '/' . (string) ( $b['owner']['slug'] ?? '' );
+					case 'accessor':
+						$oa = (string) ( $a['accessor']['type'] ?? '' ) . '/' . (string) ( $a['accessor']['slug'] ?? '' );
+						$ob = (string) ( $b['accessor']['type'] ?? '' ) . '/' . (string) ( $b['accessor']['slug'] ?? '' );
 						return $sign * strcmp( $oa, $ob );
 					case 'last_read':
 						$la = (string) ( $a['tracking']['last_read_at'] ?? '' );
@@ -637,19 +637,19 @@ final class Rest_Controller {
 	}
 
 	/**
-	 * Resolves the "active" flag for an inferred owner.
+	 * Resolves the "active" flag for an inferred accessor.
 	 *
-	 * @param array{type:string,slug:string}                                  $owner   Inferred owner.
-	 * @param array{active_plugin_slugs:string[],active_theme_slugs:string[]} $context Live site context.
+	 * @param array{type:string,slug:string}                                  $accessor Inferred accessor.
+	 * @param array{active_plugin_slugs:string[],active_theme_slugs:string[]} $context  Live site context.
 	 */
-	private static function owner_is_active( array $owner, array $context ): bool {
-		switch ( $owner['type'] ) {
+	private static function accessor_is_active( array $accessor, array $context ): bool {
+		switch ( $accessor['type'] ) {
 			case 'core':
 				return true;
 			case 'plugin':
-				return in_array( $owner['slug'], $context['active_plugin_slugs'] ?? array(), true );
+				return in_array( $accessor['slug'], $context['active_plugin_slugs'] ?? array(), true );
 			case 'theme':
-				return in_array( $owner['slug'], $context['active_theme_slugs'] ?? array(), true );
+				return in_array( $accessor['slug'], $context['active_theme_slugs'] ?? array(), true );
 			default:
 				return false;
 		}

--- a/includes/class-scorer.php
+++ b/includes/class-scorer.php
@@ -187,7 +187,27 @@ final class Scorer {
 			);
 		}
 
-		// 3. Prefix matches against installed plugin/theme slugs. Prefer plugin
+		// 3. Tracking data (backtrace-based). The tracker records which
+		// plugin/theme directory the get_option() call originated from,
+		// which is more reliable than prefix matching (e.g. Yoast SEO
+		// uses `wpseo` prefix but lives in `wordpress-seo/`). Trust
+		// tracking only when it positively identifies a plugin or theme.
+		if (
+			null !== $tracking
+			&& ! empty( $tracking['last_reader'] )
+			&& in_array(
+				(string) ( $tracking['reader_type'] ?? '' ),
+				array( self::OWNER_TYPE_PLUGIN, self::OWNER_TYPE_THEME ),
+				true
+			)
+		) {
+			return array(
+				'type' => (string) $tracking['reader_type'],
+				'slug' => (string) $tracking['last_reader'],
+			);
+		}
+
+		// 4. Prefix matches against installed plugin/theme slugs. Prefer plugin
 		// over theme when a slug happens to exist in both.
 		foreach ( ( $context['installed_plugin_slugs'] ?? array() ) as $slug ) {
 			if ( '' !== $slug && self::name_starts_with_slug( $option_name, $slug ) ) {
@@ -205,26 +225,6 @@ final class Scorer {
 					'slug' => $slug,
 				);
 			}
-		}
-
-		// 3. Tracking data is a weaker signal: "who read this option" is often
-		// WordPress core even for plugin-owned options (core loads alloptions,
-		// then plugins consume them via filters without appearing in the
-		// backtrace). Trust tracking only when it positively identifies a
-		// plugin or theme caller.
-		if (
-			null !== $tracking
-			&& ! empty( $tracking['last_reader'] )
-			&& in_array(
-				(string) ( $tracking['reader_type'] ?? '' ),
-				array( self::OWNER_TYPE_PLUGIN, self::OWNER_TYPE_THEME ),
-				true
-			)
-		) {
-			return array(
-				'type' => (string) $tracking['reader_type'],
-				'slug' => (string) $tracking['last_reader'],
-			);
 		}
 
 		return array(

--- a/includes/class-scorer.php
+++ b/includes/class-scorer.php
@@ -21,15 +21,15 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Scorer {
 
-	public const LABEL_SAFE          = 'safe';
-	public const LABEL_REVIEW        = 'review';
-	public const LABEL_LIKELY_UNUSED = 'likely_unused';
-	public const LABEL_ALMOST_UNUSED = 'almost_unused';
-	public const OWNER_TYPE_PLUGIN   = 'plugin';
-	public const OWNER_TYPE_THEME    = 'theme';
-	public const OWNER_TYPE_CORE     = 'core';
-	public const OWNER_TYPE_WIDGET   = 'widget';
-	public const OWNER_TYPE_UNKNOWN  = 'unknown';
+	public const LABEL_SAFE            = 'safe';
+	public const LABEL_REVIEW          = 'review';
+	public const LABEL_LIKELY_UNUSED   = 'likely_unused';
+	public const LABEL_ALMOST_UNUSED   = 'almost_unused';
+	public const ACCESSOR_TYPE_PLUGIN  = 'plugin';
+	public const ACCESSOR_TYPE_THEME   = 'theme';
+	public const ACCESSOR_TYPE_CORE    = 'core';
+	public const ACCESSOR_TYPE_WIDGET  = 'widget';
+	public const ACCESSOR_TYPE_UNKNOWN = 'unknown';
 
 	/**
 	 * Scores a single option row.
@@ -39,14 +39,14 @@ final class Scorer {
 	 * @param array{active_plugin_slugs:string[],installed_plugin_slugs:string[],active_theme_slugs:string[],installed_theme_slugs:string[]} $context Site context.
 	 * @param DateTimeInterface|null                                                                                                         $now Reference "now" for freshness math. Defaults to current UTC time.
 	 *
-	 * @return array{total:int,label:string,owner:array{type:string,slug:string},breakdown:array<string,int>}
+	 * @return array{total:int,label:string,accessor:array{type:string,slug:string},breakdown:array<string,int>}
 	 */
 	public static function score( array $option, ?array $tracking, array $context, ?DateTimeInterface $now = null ): array {
-		$now   = $now ?? new DateTimeImmutable( 'now' );
-		$owner = self::infer_owner( $option['option_name'], $tracking, $context );
+		$now      = $now ?? new DateTimeImmutable( 'now' );
+		$accessor = self::infer_accessor( $option['option_name'], $tracking, $context );
 
 		$breakdown = array(
-			'owner'          => self::score_owner( $owner, $context ),
+			'accessor'       => self::score_accessor( $accessor, $context ),
 			'freshness'      => self::score_freshness( $tracking, $now ),
 			'transient'      => self::score_transient( $option['option_name'] ),
 			'autoload_waste' => self::score_autoload_waste( $option, $tracking ),
@@ -58,7 +58,7 @@ final class Scorer {
 		return array(
 			'total'     => $total,
 			'label'     => self::label_for( $total ),
-			'owner'     => $owner,
+			'accessor'  => $accessor,
 			'breakdown' => $breakdown,
 		);
 	}
@@ -136,31 +136,31 @@ final class Scorer {
 	}
 
 	/**
-	 * Resolves a human-readable display name for an owner.
+	 * Resolves a human-readable display name for an accessor.
 	 *
 	 * Reads Plugin Name from the plugin header or Theme Name from style.css
 	 * via the name maps built by build_context().
 	 *
-	 * @param array{type:string,slug:string}                $owner   Inferred owner.
-	 * @param array{plugin_names?:array,theme_names?:array} $context Site context.
+	 * @param array{type:string,slug:string}                $accessor Inferred accessor.
+	 * @param array{plugin_names?:array,theme_names?:array} $context  Site context.
 	 *
 	 * @return string Display name, or the raw slug if no metadata is available.
 	 */
-	public static function resolve_owner_name( array $owner, array $context ): string {
-		if ( 'core' === $owner['type'] ) {
+	public static function resolve_accessor_name( array $accessor, array $context ): string {
+		if ( 'core' === $accessor['type'] ) {
 			return 'WordPress';
 		}
-		if ( 'plugin' === $owner['type'] && isset( $context['plugin_names'][ $owner['slug'] ] ) ) {
-			return $context['plugin_names'][ $owner['slug'] ];
+		if ( 'plugin' === $accessor['type'] && isset( $context['plugin_names'][ $accessor['slug'] ] ) ) {
+			return $context['plugin_names'][ $accessor['slug'] ];
 		}
-		if ( 'theme' === $owner['type'] && isset( $context['theme_names'][ $owner['slug'] ] ) ) {
-			return $context['theme_names'][ $owner['slug'] ];
+		if ( 'theme' === $accessor['type'] && isset( $context['theme_names'][ $accessor['slug'] ] ) ) {
+			return $context['theme_names'][ $accessor['slug'] ];
 		}
-		return ! empty( $owner['slug'] ) ? $owner['slug'] : '';
+		return ! empty( $accessor['slug'] ) ? $accessor['slug'] : '';
 	}
 
 	/**
-	 * Infers the owner of an option by consulting tracking data, prefix matches, and the core registry.
+	 * Infers the last accessor of an option by consulting tracking data, prefix matches, and the core registry.
 	 *
 	 * @param string                                                                $option_name Raw option name.
 	 * @param array{last_reader:string,reader_type:string}|null                     $tracking    Tracking record or null.
@@ -168,12 +168,12 @@ final class Scorer {
 	 *
 	 * @return array{type:string,slug:string}
 	 */
-	public static function infer_owner( string $option_name, ?array $tracking, array $context ): array {
+	public static function infer_accessor( string $option_name, ?array $tracking, array $context ): array {
 		// 1. The core registry is the strongest deterministic signal: an exact match
 		// on a curated list of WordPress-shipped option names.
 		if ( CoreOptions::contains( $option_name ) ) {
 			return array(
-				'type' => self::OWNER_TYPE_CORE,
+				'type' => self::ACCESSOR_TYPE_CORE,
 				'slug' => 'wordpress',
 			);
 		}
@@ -182,7 +182,7 @@ final class Scorer {
 		if ( 0 === strpos( $option_name, 'widget_' ) ) {
 			$widget_id = substr( $option_name, 7 ); // strip "widget_" prefix.
 			return array(
-				'type' => self::OWNER_TYPE_WIDGET,
+				'type' => self::ACCESSOR_TYPE_WIDGET,
 				'slug' => $widget_id,
 			);
 		}
@@ -197,7 +197,7 @@ final class Scorer {
 			&& ! empty( $tracking['last_reader'] )
 			&& in_array(
 				(string) ( $tracking['reader_type'] ?? '' ),
-				array( self::OWNER_TYPE_PLUGIN, self::OWNER_TYPE_THEME ),
+				array( self::ACCESSOR_TYPE_PLUGIN, self::ACCESSOR_TYPE_THEME ),
 				true
 			)
 		) {
@@ -212,7 +212,7 @@ final class Scorer {
 		foreach ( ( $context['installed_plugin_slugs'] ?? array() ) as $slug ) {
 			if ( '' !== $slug && self::name_starts_with_slug( $option_name, $slug ) ) {
 				return array(
-					'type' => self::OWNER_TYPE_PLUGIN,
+					'type' => self::ACCESSOR_TYPE_PLUGIN,
 					'slug' => $slug,
 				);
 			}
@@ -221,36 +221,36 @@ final class Scorer {
 		foreach ( ( $context['installed_theme_slugs'] ?? array() ) as $slug ) {
 			if ( '' !== $slug && self::name_starts_with_slug( $option_name, $slug ) ) {
 				return array(
-					'type' => self::OWNER_TYPE_THEME,
+					'type' => self::ACCESSOR_TYPE_THEME,
 					'slug' => $slug,
 				);
 			}
 		}
 
 		return array(
-			'type' => self::OWNER_TYPE_UNKNOWN,
+			'type' => self::ACCESSOR_TYPE_UNKNOWN,
 			'slug' => '',
 		);
 	}
 
 	/**
-	 * Axis 1 — owner state. Max 40 points.
+	 * Axis 1 — accessor state. Max 40 points.
 	 *
-	 * @param array{type:string,slug:string}                                  $owner   Inferred owner.
-	 * @param array{active_plugin_slugs:string[],active_theme_slugs:string[]} $context Site context.
+	 * @param array{type:string,slug:string}                                  $accessor Inferred accessor.
+	 * @param array{active_plugin_slugs:string[],active_theme_slugs:string[]} $context  Site context.
 	 */
-	private static function score_owner( array $owner, array $context ): int {
-		switch ( $owner['type'] ) {
-			case self::OWNER_TYPE_CORE:
+	private static function score_accessor( array $accessor, array $context ): int {
+		switch ( $accessor['type'] ) {
+			case self::ACCESSOR_TYPE_CORE:
 				return 0;
-			case self::OWNER_TYPE_WIDGET:
+			case self::ACCESSOR_TYPE_WIDGET:
 				return 0;
-			case self::OWNER_TYPE_UNKNOWN:
+			case self::ACCESSOR_TYPE_UNKNOWN:
 				return 20;
-			case self::OWNER_TYPE_PLUGIN:
-				return in_array( $owner['slug'], $context['active_plugin_slugs'] ?? array(), true ) ? 0 : 40;
-			case self::OWNER_TYPE_THEME:
-				return in_array( $owner['slug'], $context['active_theme_slugs'] ?? array(), true ) ? 0 : 40;
+			case self::ACCESSOR_TYPE_PLUGIN:
+				return in_array( $accessor['slug'], $context['active_plugin_slugs'] ?? array(), true ) ? 0 : 40;
+			case self::ACCESSOR_TYPE_THEME:
+				return in_array( $accessor['slug'], $context['active_theme_slugs'] ?? array(), true ) ? 0 : 40;
 			default:
 				return 0;
 		}

--- a/includes/class-tracker.php
+++ b/includes/class-tracker.php
@@ -296,7 +296,7 @@ final class Tracker {
 		}
 
 		// No plugin / theme / core-plugin frame in the trace: we cannot say who
-		// actually owns this read. Returning 'unknown' keeps downstream owner
+		// actually owns this read. Returning 'unknown' keeps downstream accessor
 		// inference honest — attributing to core here caused nearly every
 		// autoloaded option to be mis-labeled as WordPress-Core.
 		return array(

--- a/languages/optrion-ja.po
+++ b/languages/optrion-ja.po
@@ -105,3 +105,7 @@ msgstr "%s の上書きに失敗しました。"
 #: includes/class-rest-controller.php
 msgid "Option not found."
 msgstr "オプションが見つかりません。"
+
+#: src/tabs/OptionsList.jsx
+msgid "Accessor"
+msgstr "アクセス元"

--- a/readme.txt
+++ b/readme.txt
@@ -17,8 +17,8 @@ The `wp_options` table accumulates leftovers from plugins and themes that have b
 Optrion observes which options are actually read at runtime, scores each row on a 0–100 "probably unused" scale, and gives administrators a safe path to delete them:
 
 1. **Observe** — the tracker records when and by whom each option is read.
-2. **Score** — a deterministic 5-axis model (owner state, freshness, transient prefix, autoload waste, size) classifies each option.
-3. **Quarantine** — rename the option temporarily so WordPress and the owning plugin can no longer see it; confirm nothing breaks.
+2. **Score** — a deterministic 5-axis model (accessor state, freshness, transient prefix, autoload waste, size) classifies each option.
+3. **Quarantine** — rename the option temporarily so WordPress and the accessing plugin can no longer see it; confirm nothing breaks.
 4. **Delete** — a JSON backup is written automatically, and the row is removed from both `wp_options` and the tracking table.
 
 Core WordPress options are locked out of destructive operations.
@@ -26,8 +26,9 @@ Core WordPress options are locked out of destructive operations.
 == Features ==
 
 * Per-option read tracking via the `alloptions` filter and dynamically registered `option_{$name}` filters
-* 5-axis scoring with owner inference (live tracker data → slug prefix → core list)
+* 5-axis scoring with accessor inference (live tracker data → slug prefix → core list)
 * Quarantine mode with automatic expiry (restore / delete / keep) and a manifest table
+
 * Automatic JSON backup before any deletion, with rolling 3-generation retention
 * REST API under `/wp-json/optrion/v1/*` (requires `manage_options`)
 * WP-CLI commands for scripted pipelines

--- a/src/index.scss
+++ b/src/index.scss
@@ -76,7 +76,7 @@
 		margin-top: 12px;
 	}
 
-	.optrion-owner-type {
+	.optrion-accessor-type {
 		color: #646970;
 		font-size: 11px;
 	}

--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -41,7 +41,7 @@ const formatLastRead = ( iso ) => {
 
 const SORTABLE_COLUMNS = [
 	{ key: 'name', label: __( 'option_name', 'optrion' ) },
-	{ key: 'owner', label: __( 'Owner', 'optrion' ) },
+	{ key: 'accessor', label: __( 'Accessor', 'optrion' ) },
 	{ key: 'autoload', label: __( 'Autoload', 'optrion' ) },
 	{ key: 'size', label: __( 'Size', 'optrion' ) },
 	{ key: 'last_read', label: __( 'Last accessed', 'optrion' ) },
@@ -58,7 +58,7 @@ const OptionsList = () => {
 	const [ page, setPage ] = useState( 1 );
 	const [ search, setSearch ] = useState( '' );
 	const [ scoreMin, setScoreMin ] = useState( '' );
-	const [ ownerType, setOwnerType ] = useState( '' );
+	const [ accessorType, setAccessorType ] = useState( '' );
 	const [ orderby, setOrderby ] = useState( 'score' );
 	const [ order, setOrder ] = useState( 'desc' );
 	const [ showCore, setShowCore ] = useState( false );
@@ -71,7 +71,7 @@ const OptionsList = () => {
 			per_page: PER_PAGE,
 			search,
 			score_min: scoreMin,
-			owner_type: ownerType,
+			accessor_type: accessorType,
 			orderby,
 			order,
 		} )
@@ -82,13 +82,13 @@ const OptionsList = () => {
 			} )
 			.catch( ( e ) => setError( e.message || String( e ) ) )
 			.finally( () => setLoading( false ) );
-	}, [ page, search, scoreMin, ownerType, orderby, order ] );
+	}, [ page, search, scoreMin, accessorType, orderby, order ] );
 
 	useEffect( () => {
 		load();
 	}, [ load ] );
 
-	const isProtected = ( item ) => item && item.owner && item.owner.type === 'core';
+	const isProtected = ( item ) => item && item.accessor && item.accessor.type === 'core';
 
 	const visibleItems = showCore
 		? items
@@ -184,7 +184,7 @@ const OptionsList = () => {
 		} else {
 			setOrderby( key );
 			setOrder(
-				key === 'name' || key === 'owner' || key === 'autoload'
+				key === 'name' || key === 'accessor' || key === 'autoload'
 					? 'asc'
 					: 'desc'
 			);
@@ -225,8 +225,8 @@ const OptionsList = () => {
 					} }
 				/>
 				<SelectControl
-					label={ __( 'Owner', 'optrion' ) }
-					value={ ownerType }
+					label={ __( 'Accessor', 'optrion' ) }
+					value={ accessorType }
 					options={ [
 						{ label: __( 'All', 'optrion' ), value: '' },
 						{ label: 'plugin', value: 'plugin' },
@@ -237,7 +237,7 @@ const OptionsList = () => {
 					] }
 					onChange={ ( v ) => {
 						setPage( 1 );
-						setOwnerType( v );
+						setAccessorType( v );
 					} }
 				/>
 				<CheckboxControl
@@ -344,10 +344,10 @@ const OptionsList = () => {
 									<code>{ item.option_name }</code>
 								</td>
 								<td>
-									{ item.owner.name || item.owner.slug || '—' }
-									<span className="optrion-owner-type">
+									{ item.accessor.name || item.accessor.slug || '—' }
+									<span className="optrion-accessor-type">
 										{ ' ' }
-										({ item.owner.type })
+										({ item.accessor.type })
 									</span>
 									{ isProtected( item ) && (
 										<span

--- a/tests/test-rest-controller.php
+++ b/tests/test-rest-controller.php
@@ -79,7 +79,7 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertContains( 'rest_test_opt', $names );
 		$row = array_values( array_filter( $data['items'], static fn ( $item ) => 'rest_test_opt' === $item['option_name'] ) )[0];
 		$this->assertArrayHasKey( 'score', $row );
-		$this->assertArrayHasKey( 'owner', $row );
+		$this->assertArrayHasKey( 'accessor', $row );
 	}
 
 	/**

--- a/tests/test-scorer.php
+++ b/tests/test-scorer.php
@@ -262,13 +262,12 @@ class ScorerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Owner inference prefers a plugin-slug prefix match over tracker data,
-	 * because "who read it last" is a noisier signal than the option name
-	 * itself. For options whose name does not match any installed plugin,
-	 * tracker data with a concrete plugin caller is still used — see
-	 * {@see self::test_owner_inference_falls_back_to_tracker_caller()}.
+	 * Tracker backtrace data takes precedence over prefix matching.
+	 *
+	 * This is essential for plugins whose slug differs from the option prefix
+	 * (e.g. Yoast SEO uses `wpseo` options but lives in `wordpress-seo/`).
 	 */
-	public function test_owner_inference_prefers_prefix_over_tracker(): void {
+	public function test_owner_inference_prefers_tracker_over_prefix(): void {
 		$option   = array(
 			'option_name' => 'woocommerce_settings',
 			'size_bytes'  => 10,
@@ -282,14 +281,14 @@ class ScorerTest extends WP_UnitTestCase {
 		);
 		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
 		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
-		$this->assertSame( 'woocommerce', $result['owner']['slug'] );
+		$this->assertSame( 'custom-mu', $result['owner']['slug'] );
 	}
 
 	/**
-	 * When no prefix / registry rule matches, a concrete plugin/theme caller
-	 * in the tracker record is used to attribute ownership.
+	 * Tracker data with a concrete plugin/theme caller is used even when no
+	 * prefix or registry rule would match.
 	 */
-	public function test_owner_inference_falls_back_to_tracker_caller(): void {
+	public function test_owner_inference_uses_tracker_caller(): void {
 		$option   = array(
 			'option_name' => 'opaque_blob_42',
 			'size_bytes'  => 10,
@@ -374,7 +373,7 @@ class ScorerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Owner inference falls back to prefix matching when tracker is unknown.
+	 * Owner inference falls back to prefix matching when no tracker data exists.
 	 */
 	public function test_owner_inference_uses_prefix_match(): void {
 		$option = array(

--- a/tests/test-scorer.php
+++ b/tests/test-scorer.php
@@ -14,7 +14,7 @@ use Optrion\Scorer;
 use WP_UnitTestCase;
 
 /**
- * Covers the five scoring axes, owner inference, and label banding.
+ * Covers the five scoring axes, accessor inference, and label banding.
  *
  * @coversDefaultClass \Optrion\Scorer
  */
@@ -87,14 +87,14 @@ class ScorerTest extends WP_UnitTestCase {
 		);
 		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
 		$this->assertSame( 0, $result['total'] );
-		$this->assertSame( Scorer::OWNER_TYPE_CORE, $result['owner']['type'] );
+		$this->assertSame( Scorer::ACCESSOR_TYPE_CORE, $result['accessor']['type'] );
 		$this->assertSame( Scorer::LABEL_SAFE, $result['label'] );
 	}
 
 	/**
-	 * An option whose plugin owner is inactive accrues the 40-point owner penalty.
+	 * An option whose plugin accessor is inactive accrues the 40-point accessor penalty.
 	 */
-	public function test_inactive_plugin_owner_scores_40_on_owner_axis(): void {
+	public function test_inactive_plugin_accessor_scores_40_on_accessor_axis(): void {
 		$option   = array(
 			'option_name' => 'old_plugin_settings',
 			'size_bytes'  => 100,
@@ -102,9 +102,9 @@ class ScorerTest extends WP_UnitTestCase {
 		);
 		$tracking = null; // Never tracked.
 		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
-		$this->assertSame( 40, $result['breakdown']['owner'] );
-		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
-		$this->assertSame( 'old-plugin', $result['owner']['slug'] );
+		$this->assertSame( 40, $result['breakdown']['accessor'] );
+		$this->assertSame( Scorer::ACCESSOR_TYPE_PLUGIN, $result['accessor']['type'] );
+		$this->assertSame( 'old-plugin', $result['accessor']['slug'] );
 	}
 
 	/**
@@ -248,14 +248,14 @@ class ScorerTest extends WP_UnitTestCase {
 			'size_bytes'  => 500 * 1024,
 			'autoload'    => 'yes',
 		);
-		// Use tracker-sourced owner so the transient prefix does not block attribution.
+		// Use tracker-sourced accessor so the transient prefix does not block attribution.
 		$tracking = array(
 			'last_read_at' => null,
 			'read_count'   => 0,
 			'last_reader'  => 'old-plugin',
 			'reader_type'  => 'plugin',
 		);
-		// Owner(inactive plugin)=40 + freshness(no record)=25 + transient=10 + autoload_waste=15 + size(>100KB)=10 = 100.
+		// Accessor(inactive plugin)=40 + freshness(no record)=25 + transient=10 + autoload_waste=15 + size(>100KB)=10 = 100.
 		$result = Scorer::score( $option, $tracking, $this->context, $this->now );
 		$this->assertLessThanOrEqual( 100, $result['total'] );
 		$this->assertSame( 100, $result['total'] );
@@ -267,7 +267,7 @@ class ScorerTest extends WP_UnitTestCase {
 	 * This is essential for plugins whose slug differs from the option prefix
 	 * (e.g. Yoast SEO uses `wpseo` options but lives in `wordpress-seo/`).
 	 */
-	public function test_owner_inference_prefers_tracker_over_prefix(): void {
+	public function test_accessor_inference_prefers_tracker_over_prefix(): void {
 		$option   = array(
 			'option_name' => 'woocommerce_settings',
 			'size_bytes'  => 10,
@@ -280,15 +280,15 @@ class ScorerTest extends WP_UnitTestCase {
 			'reader_type'  => 'plugin',
 		);
 		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
-		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
-		$this->assertSame( 'custom-mu', $result['owner']['slug'] );
+		$this->assertSame( Scorer::ACCESSOR_TYPE_PLUGIN, $result['accessor']['type'] );
+		$this->assertSame( 'custom-mu', $result['accessor']['slug'] );
 	}
 
 	/**
 	 * Tracker data with a concrete plugin/theme caller is used even when no
 	 * prefix or registry rule would match.
 	 */
-	public function test_owner_inference_uses_tracker_caller(): void {
+	public function test_accessor_inference_uses_tracker_caller(): void {
 		$option   = array(
 			'option_name' => 'opaque_blob_42',
 			'size_bytes'  => 10,
@@ -301,16 +301,16 @@ class ScorerTest extends WP_UnitTestCase {
 			'reader_type'  => 'plugin',
 		);
 		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
-		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
-		$this->assertSame( 'my-analytics', $result['owner']['slug'] );
+		$this->assertSame( Scorer::ACCESSOR_TYPE_PLUGIN, $result['accessor']['type'] );
+		$this->assertSame( 'my-analytics', $result['accessor']['slug'] );
 	}
 
 	/**
 	 * Tracker records with reader_type=core provide no information about
-	 * ownership (WordPress core reads every autoloaded option). Such rows
-	 * must not promote an option to owner=core.
+	 * the accessor (WordPress core reads every autoloaded option). Such rows
+	 * must not promote an option to accessor=core.
 	 */
-	public function test_owner_inference_ignores_core_tracker_type(): void {
+	public function test_accessor_inference_ignores_core_tracker_type(): void {
 		$option   = array(
 			'option_name' => 'opaque_blob_42',
 			'size_bytes'  => 10,
@@ -323,16 +323,16 @@ class ScorerTest extends WP_UnitTestCase {
 			'reader_type'  => 'core',
 		);
 		$result   = Scorer::score( $option, $tracking, $this->context, $this->now );
-		$this->assertSame( Scorer::OWNER_TYPE_UNKNOWN, $result['owner']['type'] );
+		$this->assertSame( Scorer::ACCESSOR_TYPE_UNKNOWN, $result['accessor']['type'] );
 	}
 
 	/**
-	 * Resolve_owner_name returns the human-readable name from plugin/theme metadata.
+	 * Resolve_accessor_name returns the human-readable name from plugin/theme metadata.
 	 */
-	public function test_resolve_owner_name_from_metadata(): void {
+	public function test_resolve_accessor_name_from_metadata(): void {
 		$this->assertSame(
 			'WooCommerce',
-			Scorer::resolve_owner_name(
+			Scorer::resolve_accessor_name(
 				array(
 					'type' => 'plugin',
 					'slug' => 'woocommerce',
@@ -342,7 +342,7 @@ class ScorerTest extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			'Twenty Twenty-Four',
-			Scorer::resolve_owner_name(
+			Scorer::resolve_accessor_name(
 				array(
 					'type' => 'theme',
 					'slug' => 'twentytwentyfour',
@@ -352,7 +352,7 @@ class ScorerTest extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			'WordPress',
-			Scorer::resolve_owner_name(
+			Scorer::resolve_accessor_name(
 				array(
 					'type' => 'core',
 					'slug' => 'wordpress',
@@ -362,7 +362,7 @@ class ScorerTest extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			'',
-			Scorer::resolve_owner_name(
+			Scorer::resolve_accessor_name(
 				array(
 					'type' => 'unknown',
 					'slug' => '',
@@ -373,31 +373,31 @@ class ScorerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Owner inference falls back to prefix matching when no tracker data exists.
+	 * Accessor inference falls back to prefix matching when no tracker data exists.
 	 */
-	public function test_owner_inference_uses_prefix_match(): void {
+	public function test_accessor_inference_uses_prefix_match(): void {
 		$option = array(
 			'option_name' => 'woocommerce_settings',
 			'size_bytes'  => 10,
 			'autoload'    => 'no',
 		);
 		$result = Scorer::score( $option, null, $this->context, $this->now );
-		$this->assertSame( Scorer::OWNER_TYPE_PLUGIN, $result['owner']['type'] );
-		$this->assertSame( 'woocommerce', $result['owner']['slug'] );
+		$this->assertSame( Scorer::ACCESSOR_TYPE_PLUGIN, $result['accessor']['type'] );
+		$this->assertSame( 'woocommerce', $result['accessor']['slug'] );
 	}
 
 	/**
-	 * Unknown owner gets 20 on the owner axis.
+	 * Unknown accessor gets 20 on the accessor axis.
 	 */
-	public function test_owner_inference_defaults_to_unknown(): void {
+	public function test_accessor_inference_defaults_to_unknown(): void {
 		$option = array(
 			'option_name' => 'random_mystery_thing',
 			'size_bytes'  => 10,
 			'autoload'    => 'no',
 		);
 		$result = Scorer::score( $option, null, $this->context, $this->now );
-		$this->assertSame( Scorer::OWNER_TYPE_UNKNOWN, $result['owner']['type'] );
-		$this->assertSame( 20, $result['breakdown']['owner'] );
+		$this->assertSame( Scorer::ACCESSOR_TYPE_UNKNOWN, $result['accessor']['type'] );
+		$this->assertSame( 20, $result['breakdown']['accessor'] );
 	}
 
 	/**
@@ -412,7 +412,7 @@ class ScorerTest extends WP_UnitTestCase {
 			'autoload'    => 'no',
 		);
 		$result                            = Scorer::score( $option, null, $context, $this->now );
-		$this->assertSame( 'my-cool-plugin', $result['owner']['slug'] );
+		$this->assertSame( 'my-cool-plugin', $result['accessor']['slug'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Rename `owner` terminology to `accessor` (last accessor) across the entire codebase
- The tracker captures which plugin/theme last called `get_option()`, which is a "last accessor" signal — not true ownership
- Constants: `OWNER_TYPE_*` → `ACCESSOR_TYPE_*`
- Methods: `infer_owner` → `infer_accessor`, `score_owner` → `score_accessor`, `resolve_owner_name` → `resolve_accessor_name`
- REST API: `owner` field → `accessor`, `owner_type` param → `accessor_type`
- CLI: `--owner-type` → `--accessor-type`, output columns renamed
- Admin UI, tests, docs, translations all updated

## Test plan
- [ ] Verify REST API returns `accessor` field instead of `owner`
- [ ] Verify CLI `--accessor-type` filter works
- [ ] Verify admin UI shows "Accessor" column label (日本語: アクセス元)
- [ ] Run PHPUnit test suite
- [ ] Run JS build

Closes #86