### PR TITLE
fix: attribute autoload option reads to the real caller

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -111,12 +111,15 @@ wp_options 自体は改変せず、追跡情報を別テーブルで管理する
 
 #### フック戦略
 
-WordPress には全オプション共通の `pre_option` フックが存在しないため、2系統でカバーする。
+`get_option()` 1回ごとの呼び出し元を正確に識別できるのは `option_{$name}` フィルタだけなので、**全オプションに対して動的に `option_{$name}` フィルタを登録**する。autoload/非autoload の区別はしない。
 
 | 対象 | フック | 説明 |
 |---|---|---|
-| autoload=yes のオプション群 | `alloptions` フィルタ | WordPress が全 autoload オプションをまとめて読む時点で一括検知 |
-| autoload=no の個別オプション | `option_{$name}` フィルタ（動的登録） | admin_init 時に非 autoload オプション名一覧を取得し、ループで動的にフィルタ登録 |
+| すべての `wp_options` 行 | `option_{$name}` フィルタ（動的登録） | `plugins_loaded` 優先度 10 で全オプション名を取得し、ループで動的にフィルタ登録。`get_option()` のたびに発火するため、バックトレースから真の呼び出し元（プラグイン/テーマ）を正確に特定できる |
+
+`alloptions` フィルタは**使用しない**。`wp_load_alloptions()` は 1 リクエスト中に何度も発火し、かつ「全 autoload オプションに単一の呼び出し元をまとめて attribution する」性質上、ある瞬間の呼び出し元（Yoast 等）が無関係のオプション（WooCommerce 等）にまで上書きされてしまうため。個別に `get_option()` されない autoload オプションは tracking テーブルに行が作られないが、`list_options` REST エンドポイントは `wp_options` を起点にスコアを算出するので UI 表示には影響しない（`tracking=null` として「未読」相当のスコアが付く）。
+
+per-name フィルタを `plugins_loaded` 優先度 10 で登録するのは、Yoast SEO 等が `plugins_loaded` 優先度 14 で `get_option()` を呼ぶケースを取り逃がさないため（`admin_init` まで待つとそれらの読み込みが attribution されない）。
 
 #### 呼び出し元の特定
 

--- a/includes/class-tracker.php
+++ b/includes/class-tracker.php
@@ -64,9 +64,10 @@ final class Tracker {
 	/**
 	 * Registers tracking hooks for the current request.
 	 *
-	 * Safe to call once on `plugins_loaded`. The individual filter callbacks
-	 * short-circuit if tracking is not active so that inactive sites pay only
-	 * the cost of a transient lookup.
+	 * Intended to be called once on `plugins_loaded` (priority 10). The per-
+	 * name filters are registered immediately so that plugins hooking later
+	 * into `plugins_loaded` (e.g. Yoast SEO at priority 14) have their
+	 * `get_option()` calls captured with a correct backtrace.
 	 */
 	public static function boot(): void {
 		if ( self::$booted ) {
@@ -82,8 +83,7 @@ final class Tracker {
 		}
 		self::$request_sampled = true;
 
-		add_filter( 'alloptions', array( self::class, 'record_alloptions' ), 999 );
-		add_action( 'admin_init', array( self::class, 'register_non_autoload_hooks' ), 999 );
+		self::register_option_read_hooks();
 		add_action( 'shutdown', array( self::class, 'flush' ), 0 );
 	}
 
@@ -129,35 +129,22 @@ final class Tracker {
 	}
 
 	/**
-	 * Filter callback for `alloptions`: records every autoload option name.
+	 * Registers `option_{$name}` filters for every option row.
 	 *
-	 * @param mixed $alloptions The raw `alloptions` payload; normally an array.
-	 * @return mixed The payload unchanged.
+	 * One filter per option is the only way to attribute an individual
+	 * `get_option()` read to its caller: the filter fires at the moment of
+	 * the call, so `debug_backtrace()` shows the plugin/theme that asked.
+	 * The `alloptions` filter is deliberately not used — it fires in bulk
+	 * during core bootstrap (well before the real consumer reads), would
+	 * attribute every autoloaded option to whichever frame happens to be
+	 * on the stack when `wp_load_alloptions()` is first triggered, and
+	 * inflates read counts by mass-recording every autoloaded name on each
+	 * subsequent invocation.
 	 */
-	public static function record_alloptions( $alloptions ) {
-		if ( ! is_array( $alloptions ) ) {
-			return $alloptions;
-		}
-		$reader = self::identify_caller();
-		$now    = current_time( 'mysql', true );
-		foreach ( array_keys( $alloptions ) as $name ) {
-			self::buffer_record( (string) $name, $reader, $now );
-		}
-		return $alloptions;
-	}
-
-	/**
-	 * Registers `option_{$name}` filters for every non-autoload option.
-	 *
-	 * Runs on admin_init so that autoload-flagged rows (already covered by
-	 * the `alloptions` filter) are not double-registered.
-	 */
-	public static function register_non_autoload_hooks(): void {
+	public static function register_option_read_hooks(): void {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$names = $wpdb->get_col(
-			"SELECT option_name FROM {$wpdb->options} WHERE autoload NOT IN ('yes','on','auto','auto-on')"
-		);
+		$names = $wpdb->get_col( "SELECT option_name FROM {$wpdb->options}" );
 		if ( ! is_array( $names ) ) {
 			return;
 		}

--- a/tests/test-tracker.php
+++ b/tests/test-tracker.php
@@ -164,17 +164,26 @@ class TrackerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Recording alloptions buffers every key in the array.
+	 * Per-name filters are registered for every option, including autoloaded
+	 * rows, so that a subsequent get_option() attributes the real caller
+	 * from the live backtrace rather than a bulk-capture fallback.
 	 */
-	public function test_record_alloptions_buffers_each_key(): void {
-		$input  = array(
-			'siteurl' => 'https://example.com',
-			'home'    => 'https://example.com',
+	public function test_register_option_read_hooks_covers_autoload_options(): void {
+		add_option( 'optrion_test_autoload', 'v', '', 'yes' );
+		add_option( 'optrion_test_non_autoload', 'v', '', 'no' );
+
+		Tracker::register_option_read_hooks();
+
+		$this->assertNotFalse(
+			has_filter( 'option_optrion_test_autoload' ),
+			'Autoload option should have a per-name filter registered.'
 		);
-		$result = Tracker::record_alloptions( $input );
-		$this->assertSame( $input, $result );
-		$snapshot = Tracker::buffer_snapshot();
-		$this->assertArrayHasKey( 'siteurl', $snapshot );
-		$this->assertArrayHasKey( 'home', $snapshot );
+		$this->assertNotFalse(
+			has_filter( 'option_optrion_test_non_autoload' ),
+			'Non-autoload option should have a per-name filter registered.'
+		);
+
+		delete_option( 'optrion_test_autoload' );
+		delete_option( 'optrion_test_non_autoload' );
 	}
 }


### PR DESCRIPTION
## Summary
- Register `option_{$name}` filters for **every** option row (including autoloaded), moved to `plugins_loaded` priority 10 so reads from plugins hooking later into `plugins_loaded` (e.g. Yoast SEO at priority 14) are captured.
- Drop the `alloptions` bulk capture: it fires on every `wp_load_alloptions()` call and was attributing every autoloaded option to whichever frame happened to be on the stack, which both clobbered correct per-name attributions and inflated read counts by thousands per request.

Closes #91

## Root cause
Tracker used two hook paths with asymmetric attribution quality:
- Non-autoload: per-name `option_{$name}` filters → correct caller from the live backtrace.
- Autoload: `alloptions` filter only → fired during core bootstrap before the real consumer ran, so every autoloaded option ended up as `reader_type=unknown`.

Even naively extending per-name filters to autoload rows was not enough: `alloptions` kept firing during the request (once per `wp_load_alloptions()` call, which every `get_option()` triggers) and mass-overwrote attribution for every autoloaded option to whichever single frame was on the stack at that moment. Dropping `alloptions` and registering the per-name filters early is the minimal honest attribution path.

## Verified
Reproduced against a wp-env site with Yoast SEO active:

Before:
```
wpseo        (empty)   unknown   9153
wpseo_titles (empty)   unknown   9153
```

After:
```
wpseo        wordpress-seo   plugin   30
wpseo_titles wordpress-seo   plugin   15
```

Autoloaded options that are never individually read simply don't get a tracking row — the scorer already handles this as "untracked" and the REST `list_options` endpoint queries `wp_options` directly, so UI listing is unaffected.

## Test plan
- [ ] CI green (phpcs, PHPUnit on WP 6.8 / latest × PHP 8.3 / 8.4 / 8.5, Plugin Check).
- [ ] After fresh tracking data, Yoast's `wpseo*` options show `reader_type=plugin`, `last_reader=wordpress-seo`.
- [ ] Counts are no longer inflated into the thousands per request.
- [ ] Non-autoload attribution (e.g. `_transient_wpseo_*`) unchanged.