### PR TITLE
fix: accessor sort matches visible label; drop autoload sort

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -175,7 +175,7 @@ per-name フィルタを `plugins_loaded` 優先度 10 で登録するのは、Y
 #### 管理画面での扱い
 
 - 一覧テーブルに accessor（表示名＋type＋inactive バッジ）、autoload バッジ、サイズ、最終読み込み日時を個別カラムで表示
-- ソート: option_name / accessor / autoload / size / last_read
+- ソート: option_name / accessor（accessor.name → slug → type の優先順で表示ラベル昇順）/ size / last_read。autoload はバイナリバッジのためソート対象外
 - フィルタ: accessor type、`inactive_only`（inactive なアクセス元のみ）、`autoload_only`（autoload=yes のみ）、`search`（option_name 部分一致）
 - `_transient_*` / `_site_transient_*` と自プラグイン内部オプション（`optrion_*`, `_optrion_q__*`）は一覧から除外
 

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -52,7 +52,7 @@ final class Rest_Controller {
 						'orderby'       => array(
 							'type'    => 'string',
 							'default' => 'name',
-							'enum'    => array( 'name', 'size', 'last_read', 'accessor', 'autoload' ),
+							'enum'    => array( 'name', 'size', 'last_read', 'accessor' ),
 						),
 						'order'         => array(
 							'type'    => 'string',
@@ -596,12 +596,14 @@ final class Rest_Controller {
 				switch ( $orderby ) {
 					case 'size':
 						return $sign * ( $a['size'] <=> $b['size'] );
-					case 'autoload':
-						return $sign * strcmp( (string) $a['autoload'], (string) $b['autoload'] );
 					case 'accessor':
-						$oa = (string) ( $a['accessor']['type'] ?? '' ) . '/' . (string) ( $a['accessor']['slug'] ?? '' );
-						$ob = (string) ( $b['accessor']['type'] ?? '' ) . '/' . (string) ( $b['accessor']['slug'] ?? '' );
-						return $sign * strcmp( $oa, $ob );
+						// Sort on the visible label: the resolved accessor name falls
+						// back to the slug, then to the type. Case-insensitive so
+						// "WooCommerce" and "wordfence" sort naturally against the
+						// lowercase slugs rendered for unknown accessors.
+						$label_a = self::accessor_sort_label( $a['accessor'] ?? array() );
+						$label_b = self::accessor_sort_label( $b['accessor'] ?? array() );
+						return $sign * strcasecmp( $label_a, $label_b );
 					case 'last_read':
 						$la = (string) ( $a['tracking']['last_read_at'] ?? '' );
 						$lb = (string) ( $b['tracking']['last_read_at'] ?? '' );
@@ -612,5 +614,23 @@ final class Rest_Controller {
 				}
 			}
 		);
+	}
+
+	/**
+	 * Returns the string used to sort an accessor cell.
+	 *
+	 * Matches what the UI displays: `name` when available, otherwise `slug`,
+	 * otherwise the accessor type.
+	 *
+	 * @param array<string,mixed> $accessor Accessor payload from list_options().
+	 */
+	private static function accessor_sort_label( array $accessor ): string {
+		foreach ( array( 'name', 'slug', 'type' ) as $key ) {
+			$value = isset( $accessor[ $key ] ) ? (string) $accessor[ $key ] : '';
+			if ( '' !== $value ) {
+				return $value;
+			}
+		}
+		return '';
 	}
 }

--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -26,12 +26,12 @@ const formatLastRead = ( iso ) => {
 	return d.toLocaleString();
 };
 
-const SORTABLE_COLUMNS = [
-	{ key: 'name', label: __( 'option_name', 'optrion' ) },
-	{ key: 'accessor', label: __( 'Accessor', 'optrion' ) },
-	{ key: 'autoload', label: __( 'Autoload', 'optrion' ) },
-	{ key: 'size', label: __( 'Size', 'optrion' ) },
-	{ key: 'last_read', label: __( 'Last accessed', 'optrion' ) },
+const COLUMNS = [
+	{ key: 'name', label: __( 'option_name', 'optrion' ), sortable: true },
+	{ key: 'accessor', label: __( 'Accessor', 'optrion' ), sortable: true },
+	{ key: 'autoload', label: __( 'Autoload', 'optrion' ), sortable: false },
+	{ key: 'size', label: __( 'Size', 'optrion' ), sortable: true },
+	{ key: 'last_read', label: __( 'Last accessed', 'optrion' ), sortable: true },
 ];
 
 const OptionsList = () => {
@@ -319,23 +319,27 @@ const OptionsList = () => {
 					<thead>
 						<tr>
 							<th style={ { width: 32 } }></th>
-							{ SORTABLE_COLUMNS.map( ( col ) => (
-								<th key={ col.key }>
-									<button
-										type="button"
-										className="optrion-sort-button"
-										onClick={ () => changeSort( col.key ) }
-										aria-label={ sprintf(
-											/* translators: %s: column heading label (e.g. "Size"). */
-											__( 'Sort by %s', 'optrion' ),
-											col.label
-										) }
-									>
-										{ col.label }
-										{ sortIndicator( col.key ) }
-									</button>
-								</th>
-							) ) }
+							{ COLUMNS.map( ( col ) =>
+								col.sortable ? (
+									<th key={ col.key }>
+										<button
+											type="button"
+											className="optrion-sort-button"
+											onClick={ () => changeSort( col.key ) }
+											aria-label={ sprintf(
+												/* translators: %s: column heading label (e.g. "Size"). */
+												__( 'Sort by %s', 'optrion' ),
+												col.label
+											) }
+										>
+											{ col.label }
+											{ sortIndicator( col.key ) }
+										</button>
+									</th>
+								) : (
+									<th key={ col.key }>{ col.label }</th>
+								)
+							) }
 						</tr>
 					</thead>
 					<tbody>


### PR DESCRIPTION
## Summary
- Drop the Autoload sort button. Autoload is a binary badge; sorting on it just reshuffles rows.
- Sort the Accessor column on the rendered label (`accessor.name` → `slug` → `type`) instead of the invisible `type/slug` key, so clicking the header produces the order users expect.

Closes #95

## Verification
- Playwright against wp-env with `accessor_type=plugin`:
  - ASC: Yoast Duplicate Post → Yoast SEO
  - DESC: Yoast SEO → Yoast Duplicate Post
- Table headers: sort buttons on option_name / Accessor / Size / Last accessed only. Autoload rendered as a plain header.
- `composer test`: 74 / 221 assertions, green.
- `phpcs`: clean. `npm run build`: success.

## Test plan
- [ ] CI green.
- [ ] Clicking Accessor in the admin UI produces an alphabetical order by the rendered label (asc / desc toggle works).
- [ ] No sort arrow on the Autoload header.