### PR TITLE
release: 1.0.0 and raise minimum PHP to 8.3

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"core": null,
-	"phpVersion": "8.1",
+	"phpVersion": "8.3",
 	"plugins": [ "." ],
 	"config": {
 		"WP_DEBUG": true,

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "wordpress-plugin",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.3"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",

--- a/optrion.php
+++ b/optrion.php
@@ -3,9 +3,9 @@
  * Plugin Name:       Optrion
  * Plugin URI:        https://github.com/mt8/optrion
  * Description:       Track which plugin or theme accesses each wp_options row, then quarantine or clean orphans with an automatic backup.
- * Version:           0.1.0
+ * Version:           1.0.0
  * Requires at least: 5.8
- * Requires PHP:      7.4
+ * Requires PHP:      8.3
  * Author:            mt8biz
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'OPTRION_VERSION', '0.1.0' );
+define( 'OPTRION_VERSION', '1.0.0' );
 define( 'OPTRION_FILE', __FILE__ );
 define( 'OPTRION_DIR', plugin_dir_path( __FILE__ ) );
 define( 'OPTRION_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optrion",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Track which plugin or theme accesses each wp_options row, then quarantine or clean orphans with an automatic backup.",
   "private": true,
   "license": "GPL-2.0-or-later",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,7 @@
 	<arg name="parallel" value="1"/>
 
 	<config name="minimum_supported_wp_version" value="5.8"/>
-	<config name="testVersion" value="7.4-"/>
+	<config name="testVersion" value="8.3-"/>
 
 	<rule ref="WordPress">
 		<!-- Allow short array syntax is disabled per WP standards; keep defaults. -->

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: mt8biz
 Tags: options, database, cleanup, performance, autoload
 Requires at least: 5.8
 Tested up to: 6.9
-Requires PHP: 7.4
-Stable tag: 0.1.0
+Requires PHP: 8.3
+Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -54,8 +54,15 @@ Uninstalling restores any active quarantines to their original names, drops the 
 
 == Changelog ==
 
-= 0.1.0 =
-* Initial release.
+= 1.0.0 =
+* Initial public release.
+* Per-option read tracking: every `get_option()` call is attributed to the real plugin or theme on the PHP backtrace.
+* Options list with individual signal columns (accessor, autoload, size, last accessed) and inactive-only / autoload-only / accessor-type filters.
+* Quarantine workflow with manifest table, automatic expiry (restore / delete / keep), and a still-accessed guard that blocks deletion of options that are still being read.
+* Automatic JSON backup before every delete, with rolling 3-generation retention.
+* REST API under `/wp-json/optrion/v1/*` (requires `manage_options`).
+* WP-CLI commands for scripted pipelines, including `--accessor-type`, `--inactive-only`, and `--autoload-only` filters on `list`, `export`, and `clean`.
+* Full Japanese localization.
 
 == License ==
 


### PR DESCRIPTION
## Summary
- Bump version to **1.0.0** across \`optrion.php\` (header + \`OPTRION_VERSION\`), \`package.json\`, and \`readme.txt\` (\`Stable tag\`).
- Replace the placeholder \"0.1.0 / Initial release.\" changelog entry with a 1.0.0 first-public-release summary of what ships.
- Raise the minimum PHP runtime to **8.3** in \`optrion.php\`, \`readme.txt\`, \`composer.json\`, \`phpcs.xml.dist\` (\`testVersion\`), and \`.wp-env.json\`. The CI matrix already covers 8.3 / 8.4 / 8.5, so the matrix itself is unchanged.

Closes #104

## Release flow
After this PR merges:
1. Tag \`1.0.0\` on main — \`.github/workflows/release.yml\` will build \`optrion-1.0.0.zip\` and publish a GitHub Release.
2. Submit the resulting zip to the WordPress.org plugin directory.

## Test plan
- [ ] CI green (PHPCS, PHPUnit matrix, Plugin Check).
- [ ] Plugin header shows Version 1.0.0 and Requires PHP 8.3 in the Plugins list.
- [ ] Release workflow produces a valid \`optrion-1.0.0.zip\` containing only runtime files (no \`node_modules\`, \`src\`, \`tests\`, dotfiles).