### PR TITLE
fix(release): include build/ in the shipped zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,14 @@ jobs:
 
       - name: Stage plugin files
         run: |
-          mkdir -p build/optrion
-          rsync -a ./ build/optrion/ \
+          mkdir -p stage/optrion
+          rsync -a ./ stage/optrion/ \
             --exclude-from=.distignore \
-            --exclude='build' \
-            --exclude='.git'
+            --exclude='.git' \
+            --exclude='stage'
 
       - name: Create zip archive
-        working-directory: build
+        working-directory: stage
         run: zip -r "optrion-${{ steps.version.outputs.version }}.zip" optrion
 
       - name: Create GitHub Release
@@ -60,4 +60,4 @@ jobs:
           name: ${{ steps.version.outputs.version }}
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true
-          files: build/optrion-${{ steps.version.outputs.version }}.zip
+          files: stage/optrion-${{ steps.version.outputs.version }}.zip


### PR DESCRIPTION
## Summary
- The 1.0.0 release zip was missing \`build/\` because the staging \`rsync\` used \`build/optrion/\` as the destination and passed \`--exclude='build'\` to avoid recursing. That exclude also matched the top-level \`./build/\` produced by \`npm run build\`.
- Rename the staging directory to \`stage/\` so \`build/\` no longer has to be excluded; update the zip working-directory and release asset path.

Closes #106

## Verification
Simulated the fixed rsync locally against the current tree: \`optrion/build/index.asset.php\`, \`optrion/build/index.js\`, \`optrion/build/index.css\`, and \`optrion/build/index-rtl.css\` are all present in the produced zip.

## Release plan
Once merged, force-retag \`1.0.0\` on main so the release workflow re-runs and replaces the broken asset:

\`\`\`
git tag -f 1.0.0 origin/main
git push --force origin 1.0.0
\`\`\`