### PR TITLE
fix: address Plugin Check warnings before wp.org submission

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -16,6 +16,7 @@ node_modules
 src
 tests
 docs
+vendor
 
 CLAUDE.md
 README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,6 @@ jobs:
           node-version: '20'
           cache: npm
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          tools: composer:v2
-          coverage: none
-
       - name: Resolve version
         id: version
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
@@ -38,9 +31,6 @@ jobs:
 
       - name: Build UI bundle
         run: npm run build
-
-      - name: Install composer deps (no-dev)
-        run: composer install --no-interaction --no-progress --prefer-dist --no-dev --optimize-autoloader
 
       - name: Stage plugin files
         run: |

--- a/includes/class-cli-command.php
+++ b/includes/class-cli-command.php
@@ -394,7 +394,7 @@ final class CLI_Command {
 		}
 		$where_sql = empty( $where ) ? '' : ' WHERE ' . implode( ' AND ', $where );
 		$sql       = "SELECT option_name, option_value, autoload FROM {$wpdb->options}{$where_sql}";
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$rows          = empty( $params )
 			? $wpdb->get_results( $sql, ARRAY_A )
 			: $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A );

--- a/includes/class-exporter.php
+++ b/includes/class-exporter.php
@@ -109,7 +109,7 @@ final class Exporter {
 	private static function fetch_tracking_row( string $option_name ): ?array {
 		global $wpdb;
 		$table = Schema::tracking_table();
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$row = $wpdb->get_row(
 			$wpdb->prepare( "SELECT last_read_at, read_count, last_reader, reader_type FROM {$table} WHERE option_name = %s", $option_name ),
 			ARRAY_A

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -22,7 +22,9 @@ final class Plugin {
 	 * Registers hooks and loads modules.
 	 */
 	public static function boot(): void {
-		load_plugin_textdomain( 'optrion', false, dirname( plugin_basename( OPTRION_FILE ) ) . '/languages' );
+		// Translations are auto-loaded by WordPress via the Domain Path header
+		// (core just-in-time loader covers wp-content/languages/plugins/ and
+		// the plugin's own languages/ directory since WordPress 4.6).
 		Schema::maybe_upgrade();
 		Tracker::boot();
 		add_action( Quarantine::CRON_HOOK, array( Quarantine::class, 'process_expired' ) );

--- a/includes/class-quarantine.php
+++ b/includes/class-quarantine.php
@@ -137,7 +137,7 @@ final class Quarantine {
 		// Remove any stale manifest row (restored / deleted) so the UNIQUE KEY
 		// on original_name does not block re-quarantine.
 		$q_table = Schema::quarantine_table();
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$q_table} WHERE original_name = %s AND status != %s",
@@ -323,7 +323,7 @@ final class Quarantine {
 
 		global $wpdb;
 		$table = Schema::quarantine_table();
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT id FROM {$table} WHERE status = %s AND expires_at <= %s",
@@ -403,7 +403,7 @@ final class Quarantine {
 	public static function active_count(): int {
 		global $wpdb;
 		$table = Schema::quarantine_table();
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		return (int) $wpdb->get_var(
 			$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE status = %s", self::STATUS_ACTIVE )
 		);
@@ -420,7 +420,7 @@ final class Quarantine {
 	public static function get_manifest( int $manifest_id ): ?array {
 		global $wpdb;
 		$table = Schema::quarantine_table();
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$row = $wpdb->get_row(
 			$wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $manifest_id ),
 			ARRAY_A
@@ -468,7 +468,7 @@ final class Quarantine {
 	public static function is_still_accessed( array $manifest ): bool {
 		global $wpdb;
 		$table = Schema::tracking_table();
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$last_read = $wpdb->get_var(
 			$wpdb->prepare( "SELECT last_read_at FROM {$table} WHERE option_name = %s", $manifest['original_name'] )
 		);

--- a/includes/class-rest-controller.php
+++ b/includes/class-rest-controller.php
@@ -268,7 +268,7 @@ final class Rest_Controller {
 
 		$where_sql = empty( $where ) ? '' : ' WHERE ' . implode( ' AND ', $where );
 		$sql       = "SELECT option_name, option_value, autoload FROM {$wpdb->options}{$where_sql} ORDER BY option_name ASC";
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, WordPress.DB.PreparedSQL.NotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$rows = empty( $params )
 			? $wpdb->get_results( $sql, ARRAY_A )
 			: $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A );
@@ -478,7 +478,7 @@ final class Rest_Controller {
 		global $wpdb;
 		$status = (string) $req['status'];
 		$table  = Schema::quarantine_table();
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$rows = $wpdb->get_results(
 			$wpdb->prepare( "SELECT * FROM {$table} WHERE status = %s ORDER BY quarantined_at DESC", $status ),
 			ARRAY_A
@@ -562,7 +562,7 @@ final class Rest_Controller {
 	private static function tracking_map( array $names = array() ): array {
 		global $wpdb;
 		$table = Schema::tracking_table();
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		if ( empty( $names ) ) {
 			$rows = $wpdb->get_results( "SELECT * FROM {$table}", ARRAY_A );
 		} else {

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -131,7 +131,7 @@ final class Schema {
 	 */
 	private static function drop_legacy_columns( string $quarantine ): void {
 		global $wpdb;
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.SchemaChange, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$has_score = $wpdb->get_var(
 			$wpdb->prepare(
 				'SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %s AND COLUMN_NAME = %s',

--- a/includes/class-tracker.php
+++ b/includes/class-tracker.php
@@ -215,7 +215,7 @@ final class Tracker {
 			. ' last_reader = VALUES(last_reader),'
 			. ' reader_type = VALUES(reader_type)';
 
-		$wpdb->query( $wpdb->prepare( $sql, $values ) ); // phpcs:ignore WordPress.DB
+		$wpdb->query( $wpdb->prepare( $sql, $values ) ); // phpcs:ignore WordPress.DB, PluginCheck.Security.DirectDB.UnescapedDBParameter
 
 		self::$buffer = array();
 	}

--- a/optrion.php
+++ b/optrion.php
@@ -24,11 +24,6 @@ define( 'OPTRION_FILE', __FILE__ );
 define( 'OPTRION_DIR', plugin_dir_path( __FILE__ ) );
 define( 'OPTRION_URL', plugin_dir_url( __FILE__ ) );
 
-$optrion_autoload = OPTRION_DIR . 'vendor/autoload.php';
-if ( is_readable( $optrion_autoload ) ) {
-	require_once $optrion_autoload;
-}
-
 require_once OPTRION_DIR . 'includes/class-schema.php';
 require_once OPTRION_DIR . 'includes/class-core-options.php';
 require_once OPTRION_DIR . 'includes/class-tracker.php';

--- a/uninstall.php
+++ b/uninstall.php
@@ -23,7 +23,7 @@ function optrion_run_uninstall(): void {
 	// renamed wp_options rows when the manifest table is dropped. The
 	// plugin's classes are not autoloaded during uninstall, so the logic
 	// is inlined here.
-	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
 	$active_manifest = $wpdb->get_results(
 		$wpdb->prepare(
 			"SELECT original_name, original_autoload FROM {$quarantine_table} WHERE status = %s",
@@ -56,7 +56,7 @@ function optrion_run_uninstall(): void {
 		$quarantine_table,
 	);
 	foreach ( $tables as $table ) {
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.SchemaChange, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		$wpdb->query( 'DROP TABLE IF EXISTS ' . $table );
 	}
 


### PR DESCRIPTION
## Summary
Resolve every Plugin Check Pro warning from the latest report so the wp.org submission is clean:

- **Drop the \`vendor/\` directory from the shipped zip.** The Composer autoloader was never exercised (classes are require_once'd manually in \`optrion.php\`) and the vendor dir contained only the Composer skeleton — no third-party packages. Remove the optional \`require_once\` block from \`optrion.php\`, add \`vendor\` to \`.distignore\`, and drop the now-unused \"Install composer deps (no-dev)\" / \"Setup PHP\" steps from the release workflow.
- **Remove the manual \`load_plugin_textdomain()\` call.** WordPress 4.6+ loads translations automatically from the plugin's \`Domain Path\` directory via the just-in-time textdomain loader.
- **Suppress the \`PluginCheck.Security.DirectDB.UnescapedDBParameter\` warnings.** Every flagged query interpolates a table name resolved from \`Schema::tracking_table()\` / \`Schema::quarantine_table()\` / \`$wpdb->options\` / \`$wpdb->prefix\`, all trusted sources. We cannot use the \`%i\` placeholder because we advertise \`Requires at least: 5.8\` and \`%i\` landed in 6.2.

Closes #110

## Verification
- \`composer test\`: 74 / 221 assertions, green.
- \`phpcs\`: clean across the 24 tracked files.
- Admin UI still loads translations in Japanese locale (WordPress core just-in-time loader handles it).

## Test plan
- [ ] CI green (PHPCS, PHPUnit matrix, Plugin Check).
- [ ] Plugin Check CI reports zero warnings for the flagged codes.
- [ ] Release zip built after merge no longer contains \`optrion/vendor/\`.
- [ ] Japanese locale still renders translated strings on the admin screens.