### PR TITLE
docs(readme): refresh to 1.0 reality + add Playground demo launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,20 @@
 <h1 align="center">Optrion</h1>
 
 <p align="center">
-  <strong>Track, score, quarantine, and clean orphaned options in your WordPress database.</strong>
+  <strong>Track which plugin or theme accesses each <code>wp_options</code> row, then quarantine or clean orphans.</strong>
+</p>
+
+<p align="center">
+  <a href="https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/mt8/optrion/main/playground.json">
+    <img src="https://img.shields.io/badge/▶%20Try%20it%20live-WordPress%20Playground-21759b?style=for-the-badge&logo=wordpress&logoColor=white" alt="Try Optrion in WordPress Playground">
+  </a>
 </p>
 
 <p align="center">
   <a href="#features">Features</a> •
   <a href="#how-it-works">How It Works</a> •
-  <a href="#scoring">Scoring</a> •
   <a href="#quarantine-mode">Quarantine</a> •
+  <a href="#no-server-side-backup">No Server-Side Backup</a> •
   <a href="#wp-cli">WP-CLI</a> •
   <a href="#rest-api">REST API</a> •
   <a href="#installation">Installation</a> •
@@ -23,25 +29,29 @@
 
 ---
 
+## Try it live
+
+Click **▶ Try it live** above (or [open the demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/mt8/optrion/main/playground.json)). WordPress Playground boots a full WordPress instance entirely in your browser with Optrion and Yoast Duplicate Post pre-installed, and lands you on the Optrion admin screen. No server required.
+
 ## The Problem
 
 Every plugin and theme writes settings to the `wp_options` table. When you deactivate or delete them, those rows stay behind — forever.
 
-Over time your options table accumulates hundreds of orphaned rows, many with `autoload = yes`, quietly inflating every single page load. There's no built-in way to tell which rows are still in use, which plugin created them, or whether it's safe to remove them.
+Over time the table accumulates hundreds of orphaned rows, many with `autoload = yes`, quietly inflating every single page load. There's no built-in way to tell which rows are still in use, which plugin or theme created them, or whether it's safe to remove them.
 
-**Optrion fixes this.** It observes which options are actually read, identifies their last accessor, calculates a staleness score, and lets you safely quarantine or remove the dead weight — with full backup and one-click restore.
+**Optrion fixes this.** It observes which options are actually read at runtime, identifies the real caller from the live PHP backtrace, and surfaces the raw signals (accessor, autoload flag, size, last-read timestamp) as individual columns. Quarantine an option first to confirm nothing breaks; delete permanently only when you're sure.
 
 ## Features
 
-- **Read tracking** — hooks into `alloptions` and `option_{$name}` filters to record when each option was last read and by which plugin or theme.
-- **Accessor detection** — traces `get_option()` call stacks back to the originating plugin/theme directory. Falls back to prefix-matching against installed plugins.
-- **Staleness scoring** — rates every option 0–100 based on accessor activity, read recency, transient status, autoload waste, and data size.
-- **Quarantine mode** — renames options instead of deleting them. If something breaks, restore with one click. Auto-restores on expiry (safe by default).
-- **Bulk cleanup** — delete by score threshold, by accessor, or expired transients only. Every delete auto-creates a JSON backup.
-- **Export / Import** — full JSON backup with option values, tracking metadata, and scores. Import with dry-run preview and optional overwrite.
-- **Dashboard** — React-based admin UI with score distribution charts, autoload size metrics, and accessor breakdown.
+- **Per-option read tracking** — dynamically registers an `option_{$name}` filter for every row so every `get_option()` call is attributed to the real plugin or theme on the PHP backtrace.
+- **Accessor inference** — walks the live call stack and falls back to prefix matching. Adds an active / inactive flag so you can filter down to options whose owner is no longer installed.
+- **Individual signal columns** — sortable accessor, autoload badge, size, and last-read timestamp. No opaque composite score.
+- **Transparent quarantine** — renames the row and registers a `pre_option_{name}` filter that returns the stored value, so your site keeps running during the observation window. Any access during that window is recorded on the manifest and the Quarantine tab flags the row "in use — restore".
+- **No server-side backup** — JSON exports are browser downloads only (or operator-directed CLI output). Optrion never writes `option_value` content to the server filesystem, so secrets stored in options don't leak into `wp-content/` snapshots.
+- **Dashboard** — React-based admin UI with summary cards and an accessor breakdown.
 - **WP-CLI support** — every operation available from the command line.
 - **Core protection** — ~60 known WordPress core options are hardcoded as undeletable.
+- **i18n** — full Japanese localization included.
 
 ## How It Works
 
@@ -50,15 +60,15 @@ Over time your options table accumulates hundreds of orphaned rows, many with `a
        │
        ▼
 ┌─────────────┐     shutdown      ┌──────────────────┐
-│   Tracker    │ ──── batch ────▶ │  tracking table   │
-│ (in-memory)  │     upsert       │  last_read_at     │
+│   Tracker   │ ──── batch ────▶ │  tracking table   │
+│ (in-memory) │     upsert       │  last_read_at     │
 └─────────────┘                   │  read_count       │
                                   │  last_reader      │
                                   └────────┬──────────┘
                                            │
                                   ┌────────▼──────────┐
-                                  │     Scorer         │
-                                  │  0–100 staleness   │
+                                  │     Classifier     │
+                                  │  accessor + state  │
                                   └────────┬──────────┘
                                            │
                               ┌────────────┼────────────┐
@@ -66,71 +76,70 @@ Over time your options table accumulates hundreds of orphaned rows, many with `a
                          [ Quarantine ] [ Delete ] [ Export ]
 ```
 
-Tracking is **sampling-based and batched**. Reads are buffered in memory during a request and flushed to the database once at `shutdown`. Tracking activates automatically for 10 minutes when an admin visits the dashboard — no always-on overhead.
-
-## Scoring
-
-Each option is scored across five axes:
-
-| Axis | Max Points | Condition |
-|------|-----------|-----------|
-| **Accessor status** | 40 | Accessing plugin/theme is deactivated (40) or accessor unknown (20) |
-| **Read recency** | 25 | Last read 90+ days ago (5 pts per 30 days, capped at 25). No read recorded = 25 |
-| **Transient** | 10 | Option name starts with `_transient_` or `_site_transient_` |
-| **Autoload waste** | 15 | `autoload = yes` but zero reads during tracking period |
-| **Data size** | 10 | Over 100 KB = 10, over 10 KB = 5 |
-
-Total is capped at 100. The UI maps scores to four tiers:
-
-| Score | Label | Recommended Action |
-|-------|-------|--------------------|
-| 0–19 | Safe | Leave as is |
-| 20–49 | Review | Re-check periodically |
-| 50–79 | Likely stale | Quarantine first, then delete |
-| 80–100 | Almost certainly stale | Quarantine or export + delete |
+Tracking is **sampling-based and batched**. Reads are buffered in memory during a request and flushed to the database once at `shutdown`. Tracking activates automatically for 10 minutes when an admin visits the dashboard — no always-on overhead, no front-end cost.
 
 ## Quarantine Mode
 
 Not sure if an option is safe to delete? **Quarantine it first.**
 
-Quarantine renames the option in `wp_options` (e.g. `wpseo_titles` → `_optrion_q__wpseo_titles`) and sets `autoload` to `no`. WordPress and the accessing plugin will behave as if the option doesn't exist.
+Quarantine renames the row in `wp_options` (e.g. `wpseo_titles` → `_optrion_q__wpseo_titles`) and registers a `pre_option_{name}` filter that transparently returns the stored value from the renamed row. `get_option()` keeps returning the same value it returned before quarantine — **the site does not break the moment you quarantine**. Any access during the window is attributed via backtrace and recorded on the manifest.
 
 ```
 Quarantine ──▶ Run your site for a few days
                     │
         ┌───────────┴───────────┐
-  Something broke?         Everything fine?
+  Something accessed it?   Nothing accessed it?
         │                       │
-    [Restore]              [Permanent Delete]
-    one click               with JSON backup
+  [Restore recommended]    [Permanent Delete]
+  auto-expiry paused       enabled
 ```
-
-**Safe by default:** if the quarantine period expires without action, Optrion **auto-restores** the option and notifies the admin. You can change this to auto-delete or indefinite hold in settings.
 
 - Default quarantine period: **7 days** (configurable 1–30 days)
 - Maximum simultaneous quarantines: **50 options**
 - Core options cannot be quarantined
+- **Rows with recorded access are exempt from the expiry sweep** — the cron never auto-restores or auto-deletes a quarantine the site is still relying on
+
+## No Server-Side Backup
+
+Optrion **never writes `option_value` content to the server filesystem.** `wp_options` rows can carry API keys, SMTP credentials, payment gateway secrets, and license tokens that should not be copied into `wp-content/` — even with an `.htaccess` guard, that directory is routinely snapshot by host-level backups, misconfigured web servers, and CI/CD pipelines.
+
+If you want a restore path before deleting, take one explicit action:
+
+- **Admin UI**: Select the rows → **Export selected** → your browser downloads the JSON to your machine.
+- **WP-CLI**: `wp optrion export --names=... [--output=<path>]` → stdout by default, or an operator-chosen file path.
+
+`wp optrion clean` refuses to run without the explicit `--i-have-a-backup` flag to acknowledge that the operator has handled the backup step themselves.
 
 ## WP-CLI
 
 ```bash
-# List options with scores
-wp optrion list --score-min=50 --format=table
+# List options with accessor / autoload / size / last_read columns
+wp optrion list --format=table
 
-# Show summary statistics
+# Show only options owned by inactive plugins / themes
+wp optrion list --inactive-only
+
+# Filter by accessor type
+wp optrion list --accessor-type=plugin
+
+# Summary stats
 wp optrion stats
 
-# Export options scoring 50+ to JSON
-wp optrion export --score-min=50 --output=backup.json
+# Export options owned by inactive plugins/themes to stdout
+wp optrion export --inactive-only
 
-# Import with dry-run preview
+# Export by explicit name list to an operator-chosen file
+wp optrion export --names=opt_a,opt_b --output=backup.json
+
+# Import JSON (dry run)
 wp optrion import backup.json --dry-run
 
-# Import for real
+# Import JSON
 wp optrion import backup.json
 
-# Delete all options scoring 80+
-wp optrion clean --score-min=80 --yes
+# Bulk-delete options owned by inactive plugins/themes.
+# --i-have-a-backup is required: Optrion will not create a server-side backup.
+wp optrion clean --inactive-only --i-have-a-backup --yes
 
 # Clean up expired transients
 wp optrion clean-transients
@@ -147,7 +156,7 @@ wp optrion quarantine restore wpseo_titles
 # Permanently delete from quarantine
 wp optrion quarantine delete wpseo_titles --yes
 
-# Run expiry check (same as daily cron)
+# Run the expiry check (equivalent of the daily cron job)
 wp optrion quarantine check-expiry
 
 # Manual tracking snapshot
@@ -162,11 +171,11 @@ All endpoints require the `manage_options` capability.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/options` | List options with tracking data and scores. Supports `page`, `per_page`, `orderby`, `order`, `score_min`, `score_max`, `accessor_type`, `search`. |
+| `GET` | `/options` | List options with tracking data and accessor. Supports `page`, `per_page`, `orderby`, `order`, `accessor_type`, `inactive_only`, `autoload_only`, `search`. |
 | `GET` | `/options/{name}` | Single option detail |
-| `DELETE` | `/options` | Bulk delete (auto-backup) |
+| `DELETE` | `/options` | Bulk delete. **No server-side backup is created** — export first if you need a restore copy. |
 | `GET` | `/stats` | Summary statistics |
-| `POST` | `/export` | Export selected options to JSON |
+| `POST` | `/export` | Export selected options as JSON (response body → browser download) |
 | `POST` | `/import` | Import from JSON |
 | `POST` | `/import/preview` | Dry-run import preview |
 | `POST` | `/quarantine` | Quarantine selected options |
@@ -174,14 +183,15 @@ All endpoints require the `manage_options` capability.
 | `POST` | `/quarantine/restore` | Restore from quarantine |
 | `DELETE` | `/quarantine` | Permanently delete quarantined options |
 | `PATCH` | `/quarantine/{name}` | Extend period or update notes |
-| `POST` | `/scan` | Trigger manual tracking snapshot |
 
 ## Installation
+
+Download the latest `optrion-1.0.0.zip` from the [GitHub Releases](https://github.com/mt8/optrion/releases) page and install it through **Plugins → Add New → Upload Plugin** in your WordPress admin.
 
 ### From source
 
 ```bash
-git clone https://github.com/your-username/optrion.git
+git clone https://github.com/mt8/optrion.git
 cd optrion
 composer install
 npm install && npm run build
@@ -191,9 +201,9 @@ Copy the `optrion` directory to `wp-content/plugins/` and activate from the Word
 
 ### Requirements
 
-- WordPress 5.8+
-- PHP 7.4+
-- MySQL 5.7+ or MariaDB 10.3+
+- WordPress 6.8+
+- PHP 8.3+
+- MySQL 8.0+ or MariaDB 10.3+
 
 ## Database
 
@@ -202,15 +212,15 @@ Optrion creates two custom tables on activation. It **never modifies** the `wp_o
 | Table | Purpose |
 |-------|---------|
 | `{prefix}_options_tracking` | Stores read timestamps, counts, and reader identity for each option |
-| `{prefix}_options_quarantine` | Manages quarantine lifecycle (original name, autoload, expiry, status) |
+| `{prefix}_options_quarantine` | Manages quarantine lifecycle (original name, autoload, expiry, status, access during window) |
 
-Both tables are dropped on **uninstall** (not deactivation). Backup files in `wp-content/optrion-backups/` are also removed.
+Both tables are dropped on **uninstall** (not deactivation).
 
 ## Export Format
 
 ```json
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "exported_at": "2026-04-05T12:00:00+09:00",
   "site_url": "https://example.com",
   "wp_version": "6.8",
@@ -224,24 +234,22 @@ Both tables are dropped on **uninstall** (not deactivation). Backup files in `wp
         "read_count": 42,
         "last_reader": "some-plugin",
         "reader_type": "plugin"
-      },
-      "score": {
-        "total": 75,
-        "reasons": [...]
       }
     }
   ]
 }
 ```
 
+Legacy `1.0.0` payloads (with an extra `score` object per entry) are still accepted by the importer; the `score` field is ignored.
+
 ## Security
 
-- All operations require `manage_options` capability
-- REST API uses WordPress nonce authentication (`X-WP-Nonce`)
-- All database queries use `$wpdb->prepare()`
-- Backup directory is protected with `.htaccess`
-- Import validates JSON schema, version field, and option name characters
-- ~60 core WordPress options are hardcoded as protected and cannot be deleted or quarantined
+- All operations require the `manage_options` capability.
+- REST API relies on WordPress nonce authentication (`X-WP-Nonce`).
+- Every `$wpdb` query uses `$wpdb->prepare()`; identifiers come from `$wpdb->prefix`-derived constants.
+- **Optrion never persists `option_value` content to the server filesystem.** `Cleaner::delete()` does not write a backup; exports are browser downloads or operator-directed CLI output. No `wp-content/optrion-backups/`, no temp files, no cache.
+- Import validates JSON schema, the `version` header, and the `option_name` character class (alphanumerics, underscores, hyphens only).
+- ~60 core WordPress options are hardcoded as protected and cannot be deleted or quarantined.
 
 ## Performance
 
@@ -249,27 +257,31 @@ Both tables are dropped on **uninstall** (not deactivation). Backup files in `wp
 |---------|------------|
 | `debug_backtrace` cost | Limited to 15 frames with `IGNORE_ARGS` |
 | Per-request DB writes | Buffered in memory, single upsert at `shutdown` |
-| Non-autoload option hooks | Registered only on `admin_init`, not on frontend |
-| Large option tables | Paginated REST API (default 50/page), on-demand scoring |
+| `option_{$name}` hook registration | Once on `plugins_loaded` priority 10; not registered on the front-end (tracking short-circuits when the admin transient is off) |
+| Large option tables | Paginated REST API (default 50/page), accessor inference computed on demand |
 | Tracking overhead | Controlled via transient flag, optional sampling rate (1–100%) |
 
 ## FAQ
 
 **Does Optrion slow down my site?**
 
-No. Tracking is off by default and only activates for short windows when an admin visits the dashboard. Even when active, all DB writes are batched into a single query at shutdown. Frontend performance is unaffected.
+Not visibly. Tracking activates automatically for 10 minutes when an admin visits the dashboard — only during that window, and only for admin traffic. All writes are batched into a single upsert at shutdown. Front-end performance is unaffected. That said, Optrion adds a per-`get_option()` filter callback and a backtrace walk; the overhead is measurable on admin requests, so the admin UI shows a persistent warning asking operators to deactivate the plugin once their cleanup round is complete.
 
 **What happens if I quarantine something important?**
 
-The option is renamed, not deleted. Click "Restore" in the admin panel or run `wp optrion quarantine restore <name>` to bring it back instantly. If you do nothing, it auto-restores after the quarantine period expires.
+The site keeps working. Quarantine renames the row and installs a `pre_option_{name}` filter that transparently returns the original value; `get_option()` behavior is unchanged during the window. If anything reads the option while it is quarantined, Optrion records the access and flags the row "in use — restore". Click "Restore" (or run `wp optrion quarantine restore <name>`) to bring it back instantly.
 
-**Is it safe to delete options with a score of 80+?**
+**Is it safe to permanently delete after the quarantine window?**
 
-Scores above 80 typically mean the owning plugin is deactivated/deleted AND the option hasn't been read in months. It's very likely safe. Optrion always creates a JSON backup before any deletion, so you can restore via import if needed.
+If no access was recorded during the window, yes — nothing on the site tried to read the option for the entire period. If any access was recorded, Optrion disables the Delete button and tells you to Restore instead.
+
+**Where are my deleted options backed up?**
+
+They are not. Optrion deliberately does not persist `option_value` content to the server filesystem because `wp_options` rows can carry secrets that should not leak into `wp-content/` snapshots. If you want a restore path, use **Export selected** in the admin UI (a browser download) or `wp optrion export --output=<path>` from the CLI before deleting.
 
 **Does it work with multisite?**
 
-Currently single-site only. Multisite support (`wp_sitemeta`) is planned.
+Currently single-site only. Multisite support (`wp_sitemeta`) is on the roadmap.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Rewrite \`README.md\` so it describes what actually ships in 1.0: raw-signal columns (not a composite score), the per-name \`option_{\$name}\` tracker (not \`alloptions\`), the transparent \`pre_option_{name}\` quarantine filter, the \"no server-side backup\" invariant, and the \`--i-have-a-backup\` CLI acknowledgment.
- Update the CLI examples, REST table, export JSON shape, and FAQ to match.
- Add a prominent **▶ Try it live — WordPress Playground** shields.io button near the top that loads the \`playground.json\` blueprint so visitors can launch Optrion in their browser without installing anything.

Closes #116

## Preview
The button links to \`https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/mt8/optrion/main/playground.json\`. The blueprint pre-installs Optrion from the 1.0.0 release zip plus Yoast Duplicate Post, auto-logs in, and lands the user on the Optrion admin screen.

## Test plan
- [ ] README.md renders correctly on the repo page (including the shields.io badge).
- [ ] Clicking the button boots a WordPress Playground with Optrion active.
- [ ] No wording contradicts the 1.0 behavior (scoring references, automatic backup, etc.).