### PR TITLE
tweak(options-list): default Show WordPress-Core to on

### DIFF
--- a/src/tabs/OptionsList.jsx
+++ b/src/tabs/OptionsList.jsx
@@ -48,7 +48,7 @@ const OptionsList = () => {
 	const [ autoloadOnly, setAutoloadOnly ] = useState( false );
 	const [ orderby, setOrderby ] = useState( 'name' );
 	const [ order, setOrder ] = useState( 'asc' );
-	const [ showCore, setShowCore ] = useState( false );
+	const [ showCore, setShowCore ] = useState( true );
 
 	const load = useCallback( () => {
 		setLoading( true );


### PR DESCRIPTION
Single-line default flip so the Options list shows every row (including WordPress-Core) on first load. Core rows remain unselectable, so the extra visibility doesn't change the risk surface.

Closes #120