### PR TITLE
chore(release): 1.0.1

### DIFF
--- a/optrion.php
+++ b/optrion.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Optrion
  * Plugin URI:        https://github.com/mt8/optrion
  * Description:       Track which plugin or theme accesses each wp_options row, then quarantine or clean orphans.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Requires at least: 6.8
  * Requires PHP:      8.3
  * Author:            mt8biz
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'OPTRION_VERSION', '1.0.0' );
+define( 'OPTRION_VERSION', '1.0.1' );
 define( 'OPTRION_FILE', __FILE__ );
 define( 'OPTRION_DIR', plugin_dir_path( __FILE__ ) );
 define( 'OPTRION_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optrion",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Track which plugin or theme accesses each wp_options row, then quarantine or clean orphans.",
   "private": true,
   "license": "GPL-2.0-or-later",

--- a/playground.json
+++ b/playground.json
@@ -14,7 +14,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/mt8/optrion/releases/download/1.0.0/optrion-1.0.0.zip"
+        "url": "https://github.com/mt8/optrion/releases/download/1.0.1/optrion-1.0.1.zip"
       }
     },
     {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: options, database, cleanup, performance, autoload
 Requires at least: 6.8
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -53,6 +53,9 @@ Use Quarantine first. A quarantined option is renamed, not deleted; if anything 
 Uninstalling restores any active quarantines to their original names, drops the custom tracking and quarantine tables, removes plugin-owned options, and clears the scheduled cron job. Your regular `wp_options` data is untouched.
 
 == Changelog ==
+
+= 1.0.1 =
+* Hardened the importer to mirror the cleaner's protected-name set: WordPress core options, Optrion's own internal options (`optrion_*`), and the quarantine rename namespace are skipped instead of being written to `wp_options`. Skipped entries are reported in the import summary and the WP-CLI output.
 
 = 1.0.0 =
 * Initial public release.


### PR DESCRIPTION
## Summary

- Bumps the plugin version to 1.0.1.
- Adds the changelog entry for the importer hardening shipped in #124.
- Points the Playground demo blueprint at the upcoming `1.0.1` release zip.

## Test plan

- [x] `composer lint`
- [ ] CI matrix run on the PR
- [ ] Tag `1.0.1` after merge → release workflow publishes the zip