### PR TITLE
docs(readme): add Source code section pointing to public repo

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -56,6 +56,21 @@ Uninstalling restores any active quarantines to their original names, drops the 
 
 The orpharion is a Renaissance plucked-string instrument invented in England in 1581 by John Rose. The name is a 16th-century coinage from Orpheus and Arion, two legendary musicians of Greek mythology. Music by John Dowland, William Byrd, and others was published for it. The plugin borrows the name as a nod to the idea of carefully tuning what sits in your `wp_options` table.
 
+== Source code ==
+
+The published plugin ships with the compiled admin bundle in `build/` (`build/index.js`, `build/index.css`, `build/index.asset.php`). The non-compiled source for that bundle lives in `src/` in the public GitHub repository:
+
+* Repository: https://github.com/mt8/orpharion
+* Build tool: [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) (uses webpack + Babel under the hood).
+* Reproduce the bundle:
+
+  1. Clone the repository.
+  2. Install dependencies: `npm install` (Node.js version compatible with `@wordpress/scripts` is required).
+  3. Build: `npm run build` — produces the same `build/` files that are shipped with the plugin.
+  4. Watch mode for development: `npm run start`.
+
+PHP code is shipped uncompiled and is the same in the published ZIP and in the repository.
+
 == Changelog ==
 
 = 1.1.1 =


### PR DESCRIPTION
Closes #135

## Summary
- Adds a `== Source code ==` section to `readme.txt` between the FAQ and Changelog.
- Documents the public GitHub repository, the build tool (`@wordpress/scripts`), and the `npm install && npm run build` flow that reproduces the shipped `build/` bundle.

## Why
WordPress.org plugin review (R orpharion/mt8biz/27Apr26/T2) flagged that the compiled `build/index.js` had no publicly documented source. Per Detailed Plugin Guidelines #4, plugins shipping compiled assets must either include the non-compiled source in the ZIP or point to a public repository from the readme.

## Test plan
- [ ] Render `readme.txt` through the wp.org readme validator (or Plugin Check) and confirm the new section parses cleanly.
- [ ] Verify the GitHub URL resolves and the `src/` directory is visible.
- [ ] Re-run Plugin Check locally and confirm no new warnings are introduced.