### PR TITLE
fix(admin): enqueue menu-icon CSS via wp_add_inline_style

### DIFF
--- a/includes/class-admin-page.php
+++ b/includes/class-admin-page.php
@@ -32,12 +32,20 @@ final class Admin_Page {
 	public const HOOK_SUFFIX = 'toplevel_page_' . self::MENU_SLUG;
 
 	/**
+	 * Style handle for the menu-icon opacity override.
+	 *
+	 * Loaded on every admin page (not only the Orpharion screen) because
+	 * the top-level menu is rendered everywhere in wp-admin.
+	 */
+	private const MENU_ICON_STYLE_HANDLE = 'orpharion-menu';
+
+	/**
 	 * Registers admin hooks.
 	 */
 	public static function register(): void {
 		add_action( 'admin_menu', array( self::class, 'add_menu' ) );
+		add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_menu_icon_style' ) );
 		add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_assets' ) );
-		add_action( 'admin_head', array( self::class, 'menu_icon_css' ) );
 	}
 
 	/**
@@ -56,16 +64,24 @@ final class Admin_Page {
 	}
 
 	/**
-	 * Keeps the branded menu icon fully saturated.
+	 * Enqueues the menu-icon opacity override on every admin page.
 	 *
-	 * WordPress dims menu icon images with opacity:0.6 by default; override it
-	 * so the branded colors read at their intended intensity.
+	 * WordPress dims menu icon images with opacity:0.6 by default; this
+	 * override keeps the branded colors at their intended intensity. The
+	 * rule is attached to a no-source registered style via
+	 * wp_add_inline_style() so it goes through the standard stylesheet
+	 * pipeline rather than a raw <style> tag in admin_head.
 	 */
-	public static function menu_icon_css(): void {
-		echo '<style>'
-			. '#adminmenu .toplevel_page_' . esc_attr( self::MENU_SLUG ) . ' .wp-menu-image img'
-			. '{opacity:1;}'
-			. '</style>';
+	public static function enqueue_menu_icon_style(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		wp_register_style( self::MENU_ICON_STYLE_HANDLE, false, array(), ORPHARION_VERSION );
+		wp_enqueue_style( self::MENU_ICON_STYLE_HANDLE );
+		wp_add_inline_style(
+			self::MENU_ICON_STYLE_HANDLE,
+			'#adminmenu .toplevel_page_' . self::MENU_SLUG . ' .wp-menu-image img{opacity:1;}'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Closes #136

## Summary
- Removes the `admin_head` hook that printed a raw `<style>` tag for the menu-icon opacity override.
- Registers a no-source style handle (`orpharion-menu`) on `admin_enqueue_scripts` and attaches the rule via `wp_add_inline_style()`.
- Gates the enqueue on `current_user_can( 'manage_options' )` since the top-level menu is only rendered for that capability anyway.

## Why
WordPress.org plugin review (R orpharion/mt8biz/27Apr26/T2) flagged `includes/class-admin-page.php:65` for printing styles directly with `echo`. The icon CSS must apply on every admin page where the menu is visible (not only the Orpharion screen), so it cannot live in the existing screen-scoped `build/index.css`. Routing it through `wp_add_inline_style()` keeps it in the standard WordPress stylesheet pipeline.

## Test plan
- [ ] Activate the plugin, log in as admin, and confirm the branded menu icon stays at full opacity on Dashboard, Posts, Plugins, Users, Tools, Settings, and the Orpharion screen.
- [ ] View source on a non-Orpharion admin page and confirm the rule is attached to the `orpharion-menu` handle (not a free-standing `<style>` block).
- [ ] Log in as an Editor (no `manage_options`) and confirm the style is not enqueued.
- [ ] Run Plugin Check and confirm the previous "use wp_enqueue commands" finding is gone.