### PR TITLE
fix(tracker): route plugin-dir constants through wp_normalize_path

### DIFF
--- a/includes/class-tracker.php
+++ b/includes/class-tracker.php
@@ -248,8 +248,15 @@ final class Tracker {
 	 * @return array{type:string,slug:string}
 	 */
 	public static function classify_trace( array $trace ): array {
-		$plugins = self::normalize( defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : '' );
-		$mu      = self::normalize( defined( 'WPMU_PLUGIN_DIR' ) ? WPMU_PLUGIN_DIR : '' );
+		// WP_PLUGIN_DIR / WPMU_PLUGIN_DIR are referenced here to identify
+		// OTHER plugins' install roots so a debug_backtrace() frame can be
+		// attributed to the code that triggered the get_option() call. This
+		// mirrors how WordPress core's plugin_basename() routes file paths
+		// (see wp-includes/plugin.php). Orpharion's own location is resolved
+		// from __FILE__ via ORPHARION_DIR in orpharion.php, not from these
+		// constants.
+		$plugins = self::normalize( wp_normalize_path( WP_PLUGIN_DIR ) );
+		$mu      = self::normalize( wp_normalize_path( WPMU_PLUGIN_DIR ) );
 		$themes  = self::normalize( function_exists( 'get_theme_root' ) ? get_theme_root() : '' );
 		$self    = self::normalize( defined( 'ORPHARION_DIR' ) ? ORPHARION_DIR : '' );
 


### PR DESCRIPTION
Closes #137

## Summary
- Wraps the `WP_PLUGIN_DIR` / `WPMU_PLUGIN_DIR` references in `Tracker::classify_trace()` with `wp_normalize_path()`.
- Drops the defensive `defined()` guards on those two constants (core defines them unconditionally in `wp-includes/default-constants.php`).
- Adds a comment explaining that the constants reference *other* plugins' install roots for backtrace classification, not Orpharion's own location.

## Why
WordPress.org plugin review (R orpharion/mt8biz/27Apr26/T2) flagged the constant references at `includes/class-tracker.php:251-252`. The reviewer's documentation pointer is about determining a plugin's *own* location — which Orpharion already does correctly via `ORPHARION_DIR` (defined from `__FILE__` in `orpharion.php`). The tracker uses these constants for a different purpose: identifying which *other* plugin owns a given file path in the PHP backtrace, so each `get_option()` call can be attributed to the real caller. WordPress core itself uses these constants for the same purpose in `plugin_basename()`, so there is no function-based equivalent.

## Test plan
- [ ] `npm run test` — confirm `test_classify_trace_*` cases still pass under wp-env (they reference `WP_PLUGIN_DIR` directly to construct fixture paths).
- [ ] Manual: activate the plugin, browse a few admin pages, and confirm the options list still attributes reads to the correct accessor (e.g. WooCommerce options show `woocommerce`, not `unknown`).
- [ ] Run Plugin Check and confirm the previous "Determine files and directories locations correctly" finding is gone for these two lines.