### PR TITLE
fix: address wp.org review round 3 findings

### DIFF
--- a/docs/DESIGN-ja.md
+++ b/docs/DESIGN-ja.md
@@ -127,10 +127,12 @@ per-name フィルタを `plugins_loaded` 優先度 10 で登録するのは、Y
 
 ```
 判定ロジック:
-  ファイルパスが WP_PLUGIN_DIR 以下  → type=plugin, slug=ディレクトリ名
-  ファイルパスが get_theme_root() 以下 → type=theme,  slug=ディレクトリ名
-  上記いずれでもない                  → type=core
+  ファイルパスが plugin_basename() で短縮される → type=plugin, slug=ディレクトリ名
+  ファイルパスが get_theme_root() 以下         → type=theme,  slug=ディレクトリ名
+  上記いずれでもない                            → type=unknown
 ```
+
+`plugin_basename()` は WordPress 標準のヘルパーで、プラグインおよび MU プラグインのルートに対してファイルパスを解決する（`$wp_plugin_paths` グローバルを介してシンボリックリンクにも対応）。これを利用することで `WP_PLUGIN_DIR` / `WPMU_PLUGIN_DIR` を直接参照することなく、WP コア自体と同じ解決ロジックを再利用できる。Orpharion 自身のスタックフレームは `ORPHARION_DIR` で除外し、*次の*フレーム（実際の呼び出し元）を分類対象とする。
 
 #### パフォーマンス制御
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -127,10 +127,12 @@ The per-name filter is registered at `plugins_loaded` priority 10 (not `admin_in
 
 ```
 Classification rules:
-  file path is under WP_PLUGIN_DIR     → type=plugin, slug=directory name
-  file path is under get_theme_root()  → type=theme,  slug=directory name
-  neither of the above                 → type=unknown
+  file path resolves via plugin_basename()   → type=plugin, slug=directory name
+  file path is under get_theme_root()        → type=theme,  slug=directory name
+  neither of the above                       → type=unknown
 ```
+
+`plugin_basename()` is the WordPress-provided helper that resolves a file path against the plugins and mu-plugins roots (and is symlink-aware via the `$wp_plugin_paths` global). Routing through it avoids hard-coded references to `WP_PLUGIN_DIR` / `WPMU_PLUGIN_DIR` and inherits WP core's resolution logic verbatim. Frames inside Orpharion itself are skipped via `ORPHARION_DIR` so the *next* frame on the stack — the real caller — is the one classified.
 
 #### Performance controls
 

--- a/includes/class-tracker.php
+++ b/includes/class-tracker.php
@@ -244,21 +244,21 @@ final class Tracker {
 	 *
 	 * Pure function exposed for unit tests.
 	 *
+	 * Plugin / mu-plugin detection is delegated to the WordPress-provided
+	 * {@see plugin_basename()} helper rather than hard-coded references to
+	 * `WP_PLUGIN_DIR` / `WPMU_PLUGIN_DIR`. `plugin_basename()` already
+	 * encapsulates both plugin roots and additionally consults the
+	 * `$wp_plugin_paths` global (populated by `wp_register_plugin_realpath()`)
+	 * so symlinked plugin directories are resolved correctly. Theme frames
+	 * are detected via `get_theme_root()`, and Orpharion's own frames via
+	 * `ORPHARION_DIR` (defined from `__FILE__` in `orpharion.php`).
+	 *
 	 * @param array<int,array{file?:string}> $trace debug_backtrace() output.
 	 * @return array{type:string,slug:string}
 	 */
 	public static function classify_trace( array $trace ): array {
-		// WP_PLUGIN_DIR / WPMU_PLUGIN_DIR are referenced here to identify
-		// OTHER plugins' install roots so a debug_backtrace() frame can be
-		// attributed to the code that triggered the get_option() call. This
-		// mirrors how WordPress core's plugin_basename() routes file paths
-		// (see wp-includes/plugin.php). Orpharion's own location is resolved
-		// from __FILE__ via ORPHARION_DIR in orpharion.php, not from these
-		// constants.
-		$plugins = self::normalize( wp_normalize_path( WP_PLUGIN_DIR ) );
-		$mu      = self::normalize( wp_normalize_path( WPMU_PLUGIN_DIR ) );
-		$themes  = self::normalize( function_exists( 'get_theme_root' ) ? get_theme_root() : '' );
-		$self    = self::normalize( defined( 'ORPHARION_DIR' ) ? ORPHARION_DIR : '' );
+		$themes = self::normalize( function_exists( 'get_theme_root' ) ? get_theme_root() : '' );
+		$self   = self::normalize( defined( 'ORPHARION_DIR' ) ? ORPHARION_DIR : '' );
 
 		foreach ( $trace as $frame ) {
 			if ( empty( $frame['file'] ) ) {
@@ -266,26 +266,31 @@ final class Tracker {
 			}
 			$file = self::normalize( (string) $frame['file'] );
 
+			// Skip frames inside Orpharion itself; the next frame is the real caller.
 			if ( '' !== $self && self::starts_with( $file, $self ) ) {
 				continue;
 			}
-			if ( '' !== $plugins && self::starts_with( $file, $plugins ) ) {
-				return array(
-					'type' => 'plugin',
-					'slug' => self::extract_slug( $file, $plugins ),
-				);
-			}
-			if ( '' !== $mu && self::starts_with( $file, $mu ) ) {
-				return array(
-					'type' => 'plugin',
-					'slug' => 'mu:' . self::extract_slug( $file, $mu ),
-				);
-			}
+
+			// Theme attribution.
 			if ( '' !== $themes && self::starts_with( $file, $themes ) ) {
 				return array(
 					'type' => 'theme',
 					'slug' => self::extract_slug( $file, $themes ),
 				);
+			}
+
+			// Plugin / mu-plugin attribution. plugin_basename() returns the
+			// input unchanged (modulo leading/trailing slashes) when the file
+			// is not under either plugins root, so a successful match is
+			// detected by a strictly shorter returned length.
+			if ( function_exists( 'plugin_basename' ) ) {
+				$basename = plugin_basename( $file );
+				if ( '' !== $basename && strlen( $basename ) < strlen( ltrim( $file, '/' ) ) ) {
+					return array(
+						'type' => 'plugin',
+						'slug' => self::extract_slug( $basename, '' ),
+					);
+				}
 			}
 		}
 

--- a/orpharion.php
+++ b/orpharion.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Orpharion
  * Plugin URI:        https://github.com/mt8/orpharion
  * Description:       Track which plugin or theme accesses each wp_options row, then quarantine or clean orphans.
- * Version:           1.1.2
+ * Version:           1.1.3
  * Requires at least: 6.8
  * Requires PHP:      8.3
  * Author:            mt8biz
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'ORPHARION_VERSION', '1.1.2' );
+define( 'ORPHARION_VERSION', '1.1.3' );
 define( 'ORPHARION_FILE', __FILE__ );
 define( 'ORPHARION_DIR', plugin_dir_path( __FILE__ ) );
 define( 'ORPHARION_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orpharion",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Track which plugin or theme accesses each wp_options row, then quarantine or clean orphans.",
   "private": true,
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mt8biz
 Tags: options, database, cleanup, performance, autoload
 Requires at least: 6.8
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 8.3
 Stable tag: 1.1.3
 License: GPLv2 or later
@@ -77,6 +77,7 @@ The orpharion is a Renaissance plucked-string instrument invented in England in 
 
 = 1.1.3 =
 * readme: the **Source code** section (public GitHub repository and `npm run build` reproduction steps for the compiled admin bundle) is now placed directly after **Description** so the build-source pointer is immediately visible.
+* readme: `Tested up to` bumped to 7.0 to reflect the current WordPress release.
 * Read tracker: plugin and mu-plugin frame classification in `Tracker::classify_trace()` now goes through `plugin_basename()` instead of comparing against `WP_PLUGIN_DIR` / `WPMU_PLUGIN_DIR` directly. This reuses WP core's plugins-root resolution (including symlink awareness via `$wp_plugin_paths`) without duplicating the constant references in plugin code. Behavior is unchanged for standard setups; the legacy `mu:` slug prefix on mu-plugin readers is dropped (it was not consulted anywhere downstream).
 
 = 1.1.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: options, database, cleanup, performance, autoload
 Requires at least: 6.8
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 1.1.2
+Stable tag: 1.1.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,23 @@ Orpharion observes which options are actually read at runtime, attributes each r
 3. **Delete** — the row is removed from both `wp_options` and the tracking table. Use the **Export selected** bulk action first if you want a restore copy; Orpharion never writes option_value content to the server filesystem on your behalf (option_value can contain API keys, SMTP credentials, and other secrets that should not leak into backups of `wp-content/`).
 
 Core WordPress options are locked out of destructive operations, on both the deletion and the import side.
+
+The full PHP source ships uncompiled with the plugin; the non-compiled source of the compiled admin bundle (`build/index.js`, `build/index.css`) is published at https://github.com/mt8/orpharion — see the **Source code** section below for the exact build steps.
+
+== Source code ==
+
+The published plugin ships with the compiled admin bundle in `build/` (`build/index.js`, `build/index.css`, `build/index.asset.php`). The non-compiled source for that bundle lives in `src/` in the public GitHub repository:
+
+* Repository: https://github.com/mt8/orpharion
+* Build tool: [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) (uses webpack + Babel under the hood).
+* Reproduce the bundle:
+
+  1. Clone the repository.
+  2. Install dependencies: `npm install` (Node.js version compatible with `@wordpress/scripts` is required).
+  3. Build: `npm run build` — produces the same `build/` files that are shipped with the plugin.
+  4. Watch mode for development: `npm run start`.
+
+PHP code is shipped uncompiled and is the same in the published ZIP and in the repository.
 
 == Features ==
 
@@ -56,22 +73,11 @@ Uninstalling restores any active quarantines to their original names, drops the 
 
 The orpharion is a Renaissance plucked-string instrument invented in England in 1581 by John Rose. The name is a 16th-century coinage from Orpheus and Arion, two legendary musicians of Greek mythology. Music by John Dowland, William Byrd, and others was published for it. The plugin borrows the name as a nod to the idea of carefully tuning what sits in your `wp_options` table.
 
-== Source code ==
-
-The published plugin ships with the compiled admin bundle in `build/` (`build/index.js`, `build/index.css`, `build/index.asset.php`). The non-compiled source for that bundle lives in `src/` in the public GitHub repository:
-
-* Repository: https://github.com/mt8/orpharion
-* Build tool: [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) (uses webpack + Babel under the hood).
-* Reproduce the bundle:
-
-  1. Clone the repository.
-  2. Install dependencies: `npm install` (Node.js version compatible with `@wordpress/scripts` is required).
-  3. Build: `npm run build` — produces the same `build/` files that are shipped with the plugin.
-  4. Watch mode for development: `npm run start`.
-
-PHP code is shipped uncompiled and is the same in the published ZIP and in the repository.
-
 == Changelog ==
+
+= 1.1.3 =
+* readme: the **Source code** section (public GitHub repository and `npm run build` reproduction steps for the compiled admin bundle) is now placed directly after **Description** so the build-source pointer is immediately visible.
+* Read tracker: plugin and mu-plugin frame classification in `Tracker::classify_trace()` now goes through `plugin_basename()` instead of comparing against `WP_PLUGIN_DIR` / `WPMU_PLUGIN_DIR` directly. This reuses WP core's plugins-root resolution (including symlink awareness via `$wp_plugin_paths`) without duplicating the constant references in plugin code. Behavior is unchanged for standard setups; the legacy `mu:` slug prefix on mu-plugin readers is dropped (it was not consulted anywhere downstream).
 
 = 1.1.2 =
 * Admin menu icon: the opacity override is now attached to a registered style handle via `wp_add_inline_style()` on `admin_enqueue_scripts` instead of being printed as an inline `<style>` tag from `admin_head`. Visual behavior is unchanged.


### PR DESCRIPTION
Closes #143

## Summary

WordPress.org plugin review round 3 (Review ID `R orpharion/mt8biz/27Apr26/T3 20May26/3.9`) re-flagged the same two findings that were addressed in v1.1.2 (#135 / #137 / PRs #138 / #140). This PR re-addresses them more aggressively:

- **`readme.txt`** — the `== Source code ==` section was previously placed between FAQ and Changelog where the reviewer apparently missed it. It is now placed **immediately after `== Description ==`**, and the Description body itself ends with a one-line pointer to it plus the public GitHub URL. The section body (build tool, build steps, repository URL) is unchanged.
- **`includes/class-tracker.php`** — `Tracker::classify_trace()` no longer references `WP_PLUGIN_DIR` / `WPMU_PLUGIN_DIR` directly. Plugin and mu-plugin frame attribution now goes through `plugin_basename()`, which encapsulates both plugin roots and is symlink-aware via the `$wp_plugin_paths` global populated by `wp_register_plugin_realpath()`. Theme frames continue to use `get_theme_root()`; self-frames continue to use `ORPHARION_DIR`. The legacy `mu:` slug prefix on mu-plugin readers is dropped because nothing downstream consulted it (`Classifier::accessor_is_active()` compares against `active_plugin_slugs`, which never lists mu-plugins, so the prefix only produced misleading "inactive plugin" labels).
- **`docs/DESIGN.md` / `docs/DESIGN-ja.md`** — caller-attribution rules updated to describe the `plugin_basename()`-based classification. The Japanese version's outdated fallback ("type=core") was corrected to match the EN version ("type=unknown"), which the code has always implemented.

Version bumped to **1.1.3**.

## Test plan

- [x] `composer lint` (PHPCS / WPCS) — clean
- [x] `composer test` (PHPUnit) — 101 tests, 297 assertions, all green; the existing classify_trace tests pass unchanged because they construct frames under `WP_PLUGIN_DIR` which `plugin_basename()` correctly strips.
- [x] `npm run build` — output is identical (the source hash matches, so the bundle is byte-for-byte the same as 1.1.2's).
- [ ] Reviewer accepts the round 3 fixes.

## Out of scope

- Adding `src/` to the published ZIP (still excluded by `.distignore` — the GitHub repo is the canonical public source).